### PR TITLE
예약 요청 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'com.h2database:h2'
     testImplementation "io.rest-assured:rest-assured"
     testImplementation "io.rest-assured:json-path"

--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/service/ReservationService.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/service/ReservationService.java
@@ -85,7 +85,7 @@ public class ReservationService {
 		if (!capacity.decrease(partySize)) {
 			throw new ReservationException(ErrorCode.RESERVATION_CAPACITY_NOT_ENOUGH);
 		}
-		dailySlotCapacityRepository.update(capacity);
+		dailySlotCapacityRepository.updateRemainingCount(capacity.getCapacityId(), capacity.getRemainingCount());
 	}
 
 }

--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/service/ReservationService.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/service/ReservationService.java
@@ -1,0 +1,98 @@
+package com.reservation.tablereservationservice.application.reservation.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacity;
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacityRepository;
+import com.reservation.tablereservationservice.domain.reservation.Reservation;
+import com.reservation.tablereservationservice.domain.reservation.ReservationRepository;
+import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlot;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlotRepository;
+import com.reservation.tablereservationservice.domain.user.User;
+import com.reservation.tablereservationservice.domain.user.UserRepository;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.ReservationException;
+import com.reservation.tablereservationservice.global.exception.UserException;
+import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationRequestDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReservationService {
+
+	private final UserRepository userRepository;
+	private final RestaurantSlotRepository restaurantSlotRepository;
+	private final DailySlotCapacityRepository dailySlotCapacityRepository;
+	private final ReservationRepository reservationRepository;
+
+	@Transactional
+	public Reservation create(String email, ReservationRequestDto requestDto) {
+		User user = userRepository.findByEmail(email)
+			.orElseThrow(() -> new UserException(ErrorCode.RESOURCE_NOT_FOUND, "User"));
+
+		RestaurantSlot slot = restaurantSlotRepository.findById(requestDto.getSlotId())
+			.orElseThrow(() -> new ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "RestaurantSlot"));
+
+		LocalDateTime visitAt = calculateVisitAt(requestDto.getDate(), slot);
+
+		// 중복 시간대 예약 검증
+		validateDuplicatedTime(user.getUserId(), visitAt);
+
+		DailySlotCapacity capacity = dailySlotCapacityRepository
+			.findBySlotIdAndDate(slot.getSlotId(), requestDto.getDate())
+			.orElseThrow(() -> new ReservationException(ErrorCode.RESERVATION_SLOT_NOT_OPENED));
+
+		// 수량 검증 및 차감
+		validateEnoughCapacity(capacity, requestDto.getPartySize());
+		decreaseCapacity(capacity, requestDto.getPartySize());
+
+		Reservation reservation = Reservation.builder()
+			.userId(user.getUserId())
+			.slotId(slot.getSlotId())
+			.date(requestDto.getDate())
+			.visitAt(visitAt)
+			.partySize(requestDto.getPartySize())
+			.note(requestDto.getNote())
+			.status(ReservationStatus.CONFIRMED)
+			.build();
+
+		try {
+			return reservationRepository.save(reservation);
+		} catch (DataIntegrityViolationException e) {
+			throw new ReservationException(ErrorCode.RESERVATION_DUPLICATED_TIME);
+		}
+
+	}
+
+	private LocalDateTime calculateVisitAt(LocalDate date, RestaurantSlot slot) {
+		return LocalDateTime.of(date, slot.getTime());
+	}
+
+	private void validateDuplicatedTime(Long userId, LocalDateTime visitAt) {
+		if (reservationRepository.existsByUserIdAndVisitAtAndStatus(userId, visitAt, ReservationStatus.CONFIRMED)) {
+			throw new ReservationException(ErrorCode.RESERVATION_DUPLICATED_TIME);
+		}
+	}
+
+	private void validateEnoughCapacity(DailySlotCapacity capacity, int partySize) {
+		if (!capacity.hasEnough(partySize)) {
+			throw new ReservationException(ErrorCode.RESERVATION_CAPACITY_NOT_ENOUGH);
+		}
+	}
+
+	private void decreaseCapacity(DailySlotCapacity capacity, int partySize) {
+		capacity.decrease(partySize);
+		dailySlotCapacityRepository.update(capacity);
+
+	}
+
+}

--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/service/ReservationService.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/service/ReservationService.java
@@ -85,7 +85,7 @@ public class ReservationService {
 		if (!capacity.decrease(partySize)) {
 			throw new ReservationException(ErrorCode.RESERVATION_CAPACITY_NOT_ENOUGH);
 		}
-		dailySlotCapacityRepository.updateRemainingCount(capacity.getCapacityId(), capacity.getRemainingCount());
+		dailySlotCapacityRepository.updateRemainingCount(capacity);
 	}
 
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacity.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacity.java
@@ -13,11 +13,11 @@ public class DailySlotCapacity {
 	private LocalDate date;
 	private Integer remainingCount;
 	private Integer maxCount;
-	private long version;
+	private Long version;
 
 	@Builder
 	public DailySlotCapacity(Long capacityId, Long slotId, LocalDate date, Integer remainingCount, Integer maxCount,
-		long version) {
+		Long version) {
 		this.capacityId = capacityId;
 		this.slotId = slotId;
 		this.date = date;

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacity.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacity.java
@@ -12,33 +12,27 @@ public class DailySlotCapacity {
 	private Long slotId;
 	private LocalDate date;
 	private Integer remainingCount;
-	private Integer maxCount;
 	private Long version;
 
 	@Builder
-	public DailySlotCapacity(Long capacityId, Long slotId, LocalDate date, Integer remainingCount, Integer maxCount,
-		Long version) {
+	public DailySlotCapacity(Long capacityId, Long slotId, LocalDate date, Integer remainingCount, Long version) {
 		this.capacityId = capacityId;
 		this.slotId = slotId;
 		this.date = date;
 		this.remainingCount = remainingCount;
-		this.maxCount = maxCount;
 		this.version = version;
 	}
 
-	public void decrease(int count) {
-		this.remainingCount -= count;
+	public boolean hasEnough(int partySize) {
+		return partySize > 0 && remainingCount >= partySize;
 	}
 
-	public boolean hasEnough(int partySize) {
-		if (partySize <= 0) {
+	public boolean decrease(int partySize) {
+		if (!hasEnough(partySize)) {
 			return false;
 		}
-
-		if (partySize > maxCount) {
-			return false;
-		}
-		return remainingCount >= partySize;
+		this.remainingCount -= partySize;
+		return true;
 	}
 
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacity.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacity.java
@@ -1,0 +1,44 @@
+package com.reservation.tablereservationservice.domain.reservation;
+
+import java.time.LocalDate;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class DailySlotCapacity {
+
+	private Long capacityId;
+	private Long slotId;
+	private LocalDate date;
+	private Integer remainingCount;
+	private Integer maxCount;
+	private long version;
+
+	@Builder
+	public DailySlotCapacity(Long capacityId, Long slotId, LocalDate date, Integer remainingCount, Integer maxCount,
+		long version) {
+		this.capacityId = capacityId;
+		this.slotId = slotId;
+		this.date = date;
+		this.remainingCount = remainingCount;
+		this.maxCount = maxCount;
+		this.version = version;
+	}
+
+	public void decrease(int count) {
+		this.remainingCount -= count;
+	}
+
+	public boolean hasEnough(int partySize) {
+		if (partySize <= 0) {
+			return false;
+		}
+
+		if (partySize > maxCount) {
+			return false;
+		}
+		return remainingCount >= partySize;
+	}
+
+}

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacityRepository.java
@@ -1,0 +1,11 @@
+package com.reservation.tablereservationservice.domain.reservation;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface DailySlotCapacityRepository {
+
+	Optional<DailySlotCapacity> findBySlotIdAndDate(Long restaurantSlotId, LocalDate date);
+
+	DailySlotCapacity save(DailySlotCapacity dailySlotCapacity);
+}

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacityRepository.java
@@ -8,4 +8,6 @@ public interface DailySlotCapacityRepository {
 	Optional<DailySlotCapacity> findBySlotIdAndDate(Long restaurantSlotId, LocalDate date);
 
 	DailySlotCapacity save(DailySlotCapacity dailySlotCapacity);
+
+	void update(DailySlotCapacity dailySlotCapacity);
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacityRepository.java
@@ -10,4 +10,6 @@ public interface DailySlotCapacityRepository {
 	DailySlotCapacity save(DailySlotCapacity dailySlotCapacity);
 
 	void update(DailySlotCapacity dailySlotCapacity);
+
+	void deleteAll();
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacityRepository.java
@@ -9,7 +9,7 @@ public interface DailySlotCapacityRepository {
 
 	DailySlotCapacity save(DailySlotCapacity dailySlotCapacity);
 
-	void update(DailySlotCapacity dailySlotCapacity);
+	void updateRemainingCount(Long capacityId, Integer remainingCount);
 
 	void deleteAll();
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacityRepository.java
@@ -9,7 +9,7 @@ public interface DailySlotCapacityRepository {
 
 	DailySlotCapacity save(DailySlotCapacity dailySlotCapacity);
 
-	void updateRemainingCount(Long capacityId, Integer remainingCount);
+	void updateRemainingCount(DailySlotCapacity capacity);
 
 	void deleteAll();
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/Reservation.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/Reservation.java
@@ -1,6 +1,5 @@
 package com.reservation.tablereservationservice.domain.reservation;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import lombok.Builder;
@@ -12,19 +11,17 @@ public class Reservation {
 	private Long reservationId;
 	private Long userId;
 	private Long slotId;
-	private LocalDate date;
 	private LocalDateTime visitAt;
 	private Integer partySize;
 	private String note;
 	private ReservationStatus status;
 
 	@Builder
-	public Reservation(Long reservationId, Long userId, Long slotId, LocalDate date,
-		LocalDateTime visitAt, Integer partySize, String note, ReservationStatus status) {
+	public Reservation(Long reservationId, Long userId, Long slotId, LocalDateTime visitAt, Integer partySize,
+		String note, ReservationStatus status) {
 		this.reservationId = reservationId;
 		this.userId = userId;
 		this.slotId = slotId;
-		this.date = date;
 		this.visitAt = visitAt;
 		this.partySize = partySize;
 		this.note = note;

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/Reservation.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/Reservation.java
@@ -1,0 +1,44 @@
+package com.reservation.tablereservationservice.domain.reservation;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Reservation {
+
+	private Long reservationId;
+	private Long userId;
+	private Long restaurantId;
+	private Long slotId;
+	private LocalDate date;
+	private LocalDateTime visitAt;
+	private Integer partySize;
+	private String note;
+	private ReservationStatus status;
+
+	@Builder
+	public Reservation(Long reservationId, Long userId, Long restaurantId, Long slotId, LocalDate date,
+		LocalDateTime visitAt, Integer partySize, String note, ReservationStatus status) {
+		this.reservationId = reservationId;
+		this.userId = userId;
+		this.restaurantId = restaurantId;
+		this.slotId = slotId;
+		this.date = date;
+		this.visitAt = visitAt;
+		this.partySize = partySize;
+		this.note = note;
+		this.status = (status == null) ? ReservationStatus.PENDING : status;
+	}
+
+	public void confirm() {
+		this.status = ReservationStatus.CONFIRMED;
+	}
+
+	public void cancel() {
+		this.status = ReservationStatus.CANCELED;
+	}
+
+}

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/Reservation.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/Reservation.java
@@ -11,7 +11,6 @@ public class Reservation {
 
 	private Long reservationId;
 	private Long userId;
-	private Long restaurantId;
 	private Long slotId;
 	private LocalDate date;
 	private LocalDateTime visitAt;
@@ -20,25 +19,16 @@ public class Reservation {
 	private ReservationStatus status;
 
 	@Builder
-	public Reservation(Long reservationId, Long userId, Long restaurantId, Long slotId, LocalDate date,
+	public Reservation(Long reservationId, Long userId, Long slotId, LocalDate date,
 		LocalDateTime visitAt, Integer partySize, String note, ReservationStatus status) {
 		this.reservationId = reservationId;
 		this.userId = userId;
-		this.restaurantId = restaurantId;
 		this.slotId = slotId;
 		this.date = date;
 		this.visitAt = visitAt;
 		this.partySize = partySize;
 		this.note = note;
-		this.status = (status == null) ? ReservationStatus.PENDING : status;
-	}
-
-	public void confirm() {
-		this.status = ReservationStatus.CONFIRMED;
-	}
-
-	public void cancel() {
-		this.status = ReservationStatus.CANCELED;
+		this.status = status;
 	}
 
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/ReservationRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/ReservationRepository.java
@@ -7,4 +7,6 @@ public interface ReservationRepository {
 	Reservation save(Reservation reservation);
 
 	boolean existsByUserIdAndVisitAtAndStatus(Long userId, LocalDateTime visitAt, ReservationStatus reservationStatus);
+
+	void deleteAll();
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/ReservationRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/ReservationRepository.java
@@ -6,5 +6,5 @@ public interface ReservationRepository {
 
 	Reservation save(Reservation reservation);
 
-	boolean existsByUserIdAndVisitAt(Long userId, LocalDateTime visitAt);
+	boolean existsByUserIdAndVisitAtAndStatus(Long userId, LocalDateTime visitAt, ReservationStatus reservationStatus);
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/ReservationRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/ReservationRepository.java
@@ -1,0 +1,10 @@
+package com.reservation.tablereservationservice.domain.reservation;
+
+import java.time.LocalDateTime;
+
+public interface ReservationRepository {
+
+	Reservation save(Reservation reservation);
+
+	boolean existsByUserIdAndVisitAt(Long userId, LocalDateTime visitAt);
+}

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/ReservationStatus.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/ReservationStatus.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 @Getter
 public enum ReservationStatus {
 
-	PENDING,
 	CONFIRMED,
 	CANCELED
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/ReservationStatus.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/ReservationStatus.java
@@ -1,0 +1,11 @@
+package com.reservation.tablereservationservice.domain.reservation;
+
+import lombok.Getter;
+
+@Getter
+public enum ReservationStatus {
+
+	PENDING,
+	CONFIRMED,
+	CANCELED
+}

--- a/src/main/java/com/reservation/tablereservationservice/domain/restaurant/CategoryCode.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/restaurant/CategoryCode.java
@@ -1,0 +1,22 @@
+package com.reservation.tablereservationservice.domain.restaurant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CategoryCode {
+
+	CT01("CT01", "한식"),
+	CT02("CT02", "일식"),
+	CT03("CT03", "중식"),
+	CT04("CT04", "양식"),
+	CT05("CT05", "분식"),
+	CT06("CT06", "카페/디저트"),
+	CT07("CT07", "고기/구이"),
+	CT08("CT08", "술집/바");
+
+	private final String code;
+	private final String name;
+
+}

--- a/src/main/java/com/reservation/tablereservationservice/domain/restaurant/RegionCode.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/restaurant/RegionCode.java
@@ -1,0 +1,23 @@
+package com.reservation.tablereservationservice.domain.restaurant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RegionCode {
+	RG01("RG01", "강남/역삼"),
+    RG02("RG02", "신사/가로수길"),
+    RG03("RG03", "압구정/청담"),
+    RG04("RG04", "잠실/송파"),
+    RG05("RG05", "성수"),
+    RG06("RG06", "홍대/합정/연남"),
+    RG07("RG07", "이태원/한남"),
+    RG08("RG08", "여의도"),
+    RG09("RG09", "광화문/종로"),
+    RG10("RG10", "을지로/충무로"),
+    RG11("RG11", "용산/삼각지");
+
+	private final String code;
+	private final String name;
+}

--- a/src/main/java/com/reservation/tablereservationservice/domain/restaurant/Restaurant.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/restaurant/Restaurant.java
@@ -1,0 +1,32 @@
+package com.reservation.tablereservationservice.domain.restaurant;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Restaurant {
+
+	private Long restaurantId;
+	private Long ownerId;
+	private String regionCodeId;
+	private String categoryCodeId;
+	private String name;
+	private String address;
+	private String description;
+	private String mainMenuName;
+	private Integer mainMenuPrice;
+
+	@Builder
+	public Restaurant(Long restaurantId, Long ownerId, String regionCodeId, String categoryCodeId, String name,
+		String address, String description, String mainMenuName, Integer mainMenuPrice) {
+		this.restaurantId = restaurantId;
+		this.ownerId = ownerId;
+		this.regionCodeId = regionCodeId;
+		this.categoryCodeId = categoryCodeId;
+		this.name = name;
+		this.address = address;
+		this.description = description;
+		this.mainMenuName = mainMenuName;
+		this.mainMenuPrice = mainMenuPrice;
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/domain/restaurant/Restaurant.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/restaurant/Restaurant.java
@@ -8,8 +8,8 @@ public class Restaurant {
 
 	private Long restaurantId;
 	private Long ownerId;
-	private String regionCodeId;
-	private String categoryCodeId;
+	private RegionCode regionCode;
+	private CategoryCode categoryCode;
 	private String name;
 	private String address;
 	private String description;
@@ -17,12 +17,12 @@ public class Restaurant {
 	private Integer mainMenuPrice;
 
 	@Builder
-	public Restaurant(Long restaurantId, Long ownerId, String regionCodeId, String categoryCodeId, String name,
+	public Restaurant(Long restaurantId, Long ownerId, RegionCode regionCode, CategoryCode categoryCode, String name,
 		String address, String description, String mainMenuName, Integer mainMenuPrice) {
 		this.restaurantId = restaurantId;
 		this.ownerId = ownerId;
-		this.regionCodeId = regionCodeId;
-		this.categoryCodeId = categoryCodeId;
+		this.regionCode = regionCode;
+		this.categoryCode = categoryCode;
 		this.name = name;
 		this.address = address;
 		this.description = description;

--- a/src/main/java/com/reservation/tablereservationservice/domain/restaurant/RestaurantRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/restaurant/RestaurantRepository.java
@@ -1,0 +1,10 @@
+package com.reservation.tablereservationservice.domain.restaurant;
+
+import java.util.Optional;
+
+public interface RestaurantRepository {
+
+	Optional<Restaurant> findById(Long restaurantId);
+
+	Restaurant save(Restaurant restaurant);
+}

--- a/src/main/java/com/reservation/tablereservationservice/domain/restaurant/RestaurantRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/restaurant/RestaurantRepository.java
@@ -7,4 +7,6 @@ public interface RestaurantRepository {
 	Optional<Restaurant> findById(Long restaurantId);
 
 	Restaurant save(Restaurant restaurant);
+
+	void deleteAll();
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/restaurant/RestaurantSlot.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/restaurant/RestaurantSlot.java
@@ -1,0 +1,23 @@
+package com.reservation.tablereservationservice.domain.restaurant;
+
+import java.time.LocalTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class RestaurantSlot {
+
+	private Long slotId;
+	private Long restaurantId;
+	private LocalTime time;
+	private Integer maxCapacity;
+
+	@Builder
+	public RestaurantSlot(Long slotId, Long restaurantId, LocalTime time, Integer maxCapacity) {
+		this.slotId = slotId;
+		this.restaurantId = restaurantId;
+		this.time = time;
+		this.maxCapacity = maxCapacity;
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/domain/restaurant/RestaurantSlot.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/restaurant/RestaurantSlot.java
@@ -20,4 +20,8 @@ public class RestaurantSlot {
 		this.time = time;
 		this.maxCapacity = maxCapacity;
 	}
+
+	public boolean canAcceptPartySize(int partySize) {
+		return partySize > 0 && partySize <= maxCapacity;
+	}
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/restaurant/RestaurantSlotRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/restaurant/RestaurantSlotRepository.java
@@ -8,4 +8,6 @@ public interface RestaurantSlotRepository {
 
 	RestaurantSlot save(RestaurantSlot restaurantSlot);
 
+	void deleteAll();
+
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/restaurant/RestaurantSlotRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/restaurant/RestaurantSlotRepository.java
@@ -6,4 +6,6 @@ public interface RestaurantSlotRepository {
 
 	Optional<RestaurantSlot> findById(Long slotId);
 
+	RestaurantSlot save(RestaurantSlot restaurantSlot);
+
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/restaurant/RestaurantSlotRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/restaurant/RestaurantSlotRepository.java
@@ -1,0 +1,9 @@
+package com.reservation.tablereservationservice.domain.restaurant;
+
+import java.util.Optional;
+
+public interface RestaurantSlotRepository {
+
+	Optional<RestaurantSlot> findById(Long slotId);
+
+}

--- a/src/main/java/com/reservation/tablereservationservice/domain/restaurant/RestaurantSlotRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/restaurant/RestaurantSlotRepository.java
@@ -8,6 +8,8 @@ public interface RestaurantSlotRepository {
 
 	RestaurantSlot save(RestaurantSlot restaurantSlot);
 
+	RestaurantSlot fetchById(Long slotId);
+
 	void deleteAll();
 
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/user/UserRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/user/UserRepository.java
@@ -12,5 +12,7 @@ public interface UserRepository {
 
 	Optional<User> findByEmail(String email);
 
+	User fetchByEmail(String email);
+
 	void deleteAll();
 }

--- a/src/main/java/com/reservation/tablereservationservice/global/config/SecurityConfig.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.reservation.tablereservationservice.global.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -21,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/reservation/tablereservationservice/global/exception/ErrorCode.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/exception/ErrorCode.java
@@ -12,6 +12,9 @@ public enum ErrorCode {
 	// 400 Bad Request
 	INVALID_INPUT_VALUE("잘못된 입력 값입니다.", HttpStatus.BAD_REQUEST),
 	MISSING_PARAMETER("필수 파라미터가 누락되었습니다.", HttpStatus.BAD_REQUEST),
+	INVALID_PARTY_SIZE("예약 인원 수가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+	RESERVATION_SLOT_NOT_OPENED("해당 날짜의 예약이 오픈되지 않았습니다.", HttpStatus.BAD_REQUEST),
+	INVALID_RESERVATION_REQUEST("유효하지 않은 예약 요청입니다.", HttpStatus.BAD_REQUEST),
 
 	// 401 Unauthorized
 	UNAUTHORIZED("인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
@@ -27,6 +30,11 @@ public enum ErrorCode {
 
 	// 409 Conflict
 	DUPLICATE_RESOURCE("%s 값이 이미 존재합니다.", HttpStatus.CONFLICT),
+	// 예약 정책 충돌
+	RESERVATION_DUPLICATED_TIME("동시간대에 이미 예약이 존재합니다.", HttpStatus.CONFLICT),
+	RESERVATION_CAPACITY_NOT_ENOUGH("예약 가능 좌석이 부족합니다.", HttpStatus.CONFLICT),
+	// 동시성 충돌
+	RESERVATION_NOT_AVAILABLE("다른 예약이 선점되었습니다.", HttpStatus.CONFLICT),
 
 	// 500 Internal Server Error
 	INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/reservation/tablereservationservice/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -43,6 +44,17 @@ public class GlobalExceptionHandler {
 		return ResponseEntity
 			.status(errorCode.getStatus())
 			.body(ApiResponse.error(errorCode.getStatus(), errorCode.getMessage(), errors));
+	}
+
+	@ExceptionHandler(AuthorizationDeniedException.class)
+	public ResponseEntity<ApiResponse<Void>> handleAuthorizationDeniedException(AuthorizationDeniedException e) {
+		log.warn("Authorization denied: {}", e.getMessage());
+
+		ErrorCode errorCode = ErrorCode.ACCESS_DENIED; // 403
+
+		return ResponseEntity
+			.status(errorCode.getStatus())
+			.body(ApiResponse.error(errorCode.getStatus(), errorCode.getMessage()));
 	}
 
 	@ExceptionHandler(Exception.class)

--- a/src/main/java/com/reservation/tablereservationservice/global/exception/ReservationException.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/exception/ReservationException.java
@@ -1,0 +1,8 @@
+package com.reservation.tablereservationservice.global.exception;
+
+public class ReservationException extends BusinessException {
+
+	public ReservationException(ErrorCode errorCode, Object... args) {
+		super(errorCode, args);
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/global/exception/RestaurantException.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/exception/RestaurantException.java
@@ -1,0 +1,8 @@
+package com.reservation.tablereservationservice.global.exception;
+
+public class RestaurantException extends BusinessException {
+
+	public RestaurantException(ErrorCode errorCode, Object... args) {
+		super(errorCode, args);
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/DailySlotCapacityEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/DailySlotCapacityEntity.java
@@ -51,11 +51,16 @@ public class DailySlotCapacityEntity extends BaseTimeEntity {
 	private Long version;
 
 	@Builder
-	public DailySlotCapacityEntity(RestaurantSlotEntity slot, LocalDate date, Integer remainingCount, Integer maxCount) {
+	public DailySlotCapacityEntity(RestaurantSlotEntity slot, LocalDate date, Integer remainingCount,
+		Integer maxCount) {
 		this.slot = slot;
 		this.date = date;
 		this.remainingCount = remainingCount;
 		this.maxCount = maxCount;
+	}
+
+	public void assignSlot(RestaurantSlotEntity restaurantSlot) {
+		this.slot = restaurantSlot;
 	}
 
 	public void updateRemainingCount(Integer remainingCount) {

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/DailySlotCapacityEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/DailySlotCapacityEntity.java
@@ -3,16 +3,12 @@ package com.reservation.tablereservationservice.infrastructure.reservation.entit
 import java.time.LocalDate;
 
 import com.reservation.tablereservationservice.infrastructure.common.entity.BaseTimeEntity;
-import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantSlotEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Version;
@@ -22,10 +18,15 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "daily_slot_capacity",
+@Table(
+	name = "daily_slot_capacity",
 	uniqueConstraints = {
-		@UniqueConstraint(name = "uq_slot_date", columnNames = {"capacity_slot_id", "capacity_date"})
-	})
+		@UniqueConstraint(
+			name = "uq_slot_date",
+			columnNames = {"slot_id", "date"}
+		)
+	}
+)
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class DailySlotCapacityEntity extends BaseTimeEntity {
 
@@ -33,34 +34,24 @@ public class DailySlotCapacityEntity extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long capacityId;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "capacity_slot_id", nullable = false)
-	private RestaurantSlotEntity slot;
+	@Column(nullable = false)
+	private Long slotId;
 
-	@Column(name = "capacity_date", nullable = false)
+	@Column(nullable = false)
 	private LocalDate date;
 
-	@Column(name = "capacity_remaining_count", nullable = false)
+	@Column(nullable = false)
 	private Integer remainingCount;
 
-	@Column(name = "capacity_max_count", nullable = false)
-	private Integer maxCount;
-
 	@Version
-	@Column(name = "capacity_version", nullable = false)
+	@Column(nullable = false)
 	private Long version;
 
 	@Builder
-	public DailySlotCapacityEntity(RestaurantSlotEntity slot, LocalDate date, Integer remainingCount,
-		Integer maxCount) {
-		this.slot = slot;
+	public DailySlotCapacityEntity(Long slotId, LocalDate date, Integer remainingCount) {
+		this.slotId = slotId;
 		this.date = date;
 		this.remainingCount = remainingCount;
-		this.maxCount = maxCount;
-	}
-
-	public void assignSlot(RestaurantSlotEntity restaurantSlot) {
-		this.slot = restaurantSlot;
 	}
 
 	public void updateRemainingCount(Integer remainingCount) {

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/DailySlotCapacityEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/DailySlotCapacityEntity.java
@@ -1,0 +1,64 @@
+package com.reservation.tablereservationservice.infrastructure.reservation.entity;
+
+import java.time.LocalDate;
+
+import com.reservation.tablereservationservice.infrastructure.common.entity.BaseTimeEntity;
+import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantSlotEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "daily_slot_capacity",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uq_slot_date", columnNames = {"capacity_slot_id", "capacity_date"})
+	})
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class DailySlotCapacityEntity extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long capacityId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "capacity_slot_id", nullable = false)
+	private RestaurantSlotEntity slot;
+
+	@Column(name = "capacity_date", nullable = false)
+	private LocalDate date;
+
+	@Column(name = "capacity_remaining_count", nullable = false)
+	private Integer remainingCount;
+
+	@Column(name = "capacity_max_count", nullable = false)
+	private Integer maxCount;
+
+	@Version
+	@Column(name = "capacity_version", nullable = false)
+	private Long version;
+
+	@Builder
+	public DailySlotCapacityEntity(RestaurantSlotEntity slot, LocalDate date, Integer remainingCount, Integer maxCount) {
+		this.slot = slot;
+		this.date = date;
+		this.remainingCount = remainingCount;
+		this.maxCount = maxCount;
+	}
+
+	public void updateRemainingCount(Integer remainingCount) {
+		this.remainingCount = remainingCount;
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/ReservationEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/ReservationEntity.java
@@ -1,6 +1,5 @@
 package com.reservation.tablereservationservice.infrastructure.reservation.entity;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
@@ -49,9 +48,6 @@ public class ReservationEntity extends BaseTimeEntity {
 	@JoinColumn(name = "reservation_slot_id", nullable = false)
 	private RestaurantSlotEntity slot;
 
-	@Column(name = "reservation_date", nullable = false)
-	private LocalDate date;
-
 	@Column(name = "reservation_visit_at", nullable = false)
 	private LocalDateTime visitAt;
 
@@ -66,11 +62,10 @@ public class ReservationEntity extends BaseTimeEntity {
 	private ReservationStatus status;
 
 	@Builder
-	public ReservationEntity(Long userId, RestaurantSlotEntity slot, LocalDate date,
-		LocalDateTime visitAt, Integer partySize, String note, ReservationStatus status) {
+	public ReservationEntity(Long userId, RestaurantSlotEntity slot, LocalDateTime visitAt, Integer partySize,
+		String note, ReservationStatus status) {
 		this.userId = userId;
 		this.slot = slot;
-		this.date = date;
 		this.visitAt = visitAt;
 		this.partySize = partySize;
 		this.note = note;

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/ReservationEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/ReservationEntity.java
@@ -1,0 +1,93 @@
+package com.reservation.tablereservationservice.infrastructure.reservation.entity;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
+import com.reservation.tablereservationservice.infrastructure.common.entity.BaseTimeEntity;
+import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantEntity;
+import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantSlotEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(
+	name = "reservation",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uq_user_visit_at",
+			columnNames = {"reservation_user_id", "reservation_visit_at"}
+		)
+	}
+)
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+
+public class ReservationEntity extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long reservationId;
+
+	@Column(name = "reservation_user_id", nullable = false)
+	private Long userId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "reservation_restaurant_id", nullable = false)
+	private RestaurantEntity restaurant;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "reservation_slot_id", nullable = false)
+	private RestaurantSlotEntity slot;
+
+	@Column(name = "reservation_date", nullable = false)
+	private LocalDate date;
+
+	@Column(name = "reservation_visit_at", nullable = false)
+	private LocalDateTime visitAt;
+
+	@Column(name = "reservation_party_size", nullable = false)
+	private Integer partySize;
+
+	@Column(name = "reservation_note")
+	private String note;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "reservation_status", nullable = false, length = 20)
+	private ReservationStatus status;
+
+	@Builder
+	public ReservationEntity(Long userId, RestaurantEntity restaurant, RestaurantSlotEntity slot, LocalDate date,
+		LocalDateTime visitAt, Integer partySize, String note, ReservationStatus status) {
+		this.userId = userId;
+		this.restaurant = restaurant;
+		this.slot = slot;
+		this.date = date;
+		this.visitAt = visitAt;
+		this.partySize = partySize;
+		this.note = note;
+		this.status = status;
+	}
+
+	public void assignRestaurant(RestaurantEntity restaurant) {
+		this.restaurant = restaurant;
+	}
+
+	public void assignSlot(RestaurantSlotEntity slot) {
+		this.slot = slot;
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/ReservationEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/ReservationEntity.java
@@ -5,7 +5,6 @@ import java.time.LocalDateTime;
 
 import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
 import com.reservation.tablereservationservice.infrastructure.common.entity.BaseTimeEntity;
-import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantEntity;
 import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantSlotEntity;
 
 import jakarta.persistence.Column;
@@ -47,10 +46,6 @@ public class ReservationEntity extends BaseTimeEntity {
 	private Long userId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "reservation_restaurant_id", nullable = false)
-	private RestaurantEntity restaurant;
-
-	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "reservation_slot_id", nullable = false)
 	private RestaurantSlotEntity slot;
 
@@ -71,20 +66,15 @@ public class ReservationEntity extends BaseTimeEntity {
 	private ReservationStatus status;
 
 	@Builder
-	public ReservationEntity(Long userId, RestaurantEntity restaurant, RestaurantSlotEntity slot, LocalDate date,
+	public ReservationEntity(Long userId, RestaurantSlotEntity slot, LocalDate date,
 		LocalDateTime visitAt, Integer partySize, String note, ReservationStatus status) {
 		this.userId = userId;
-		this.restaurant = restaurant;
 		this.slot = slot;
 		this.date = date;
 		this.visitAt = visitAt;
 		this.partySize = partySize;
 		this.note = note;
 		this.status = status;
-	}
-
-	public void assignRestaurant(RestaurantEntity restaurant) {
-		this.restaurant = restaurant;
 	}
 
 	public void assignSlot(RestaurantSlotEntity slot) {

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/ReservationEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/ReservationEntity.java
@@ -4,18 +4,14 @@ import java.time.LocalDateTime;
 
 import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
 import com.reservation.tablereservationservice.infrastructure.common.entity.BaseTimeEntity;
-import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantSlotEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.Builder;
@@ -29,7 +25,7 @@ import lombok.NoArgsConstructor;
 	uniqueConstraints = {
 		@UniqueConstraint(
 			name = "uq_user_visit_at",
-			columnNames = {"reservation_user_id", "reservation_visit_at"}
+			columnNames = {"user_id", "visit_at"}
 		)
 	}
 )
@@ -41,38 +37,32 @@ public class ReservationEntity extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long reservationId;
 
-	@Column(name = "reservation_user_id", nullable = false)
+	@Column(nullable = false)
 	private Long userId;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "reservation_slot_id", nullable = false)
-	private RestaurantSlotEntity slot;
+	@Column(nullable = false)
+	private Long slotId;
 
-	@Column(name = "reservation_visit_at", nullable = false)
+	@Column(nullable = false)
 	private LocalDateTime visitAt;
 
-	@Column(name = "reservation_party_size", nullable = false)
+	@Column(nullable = false)
 	private Integer partySize;
 
-	@Column(name = "reservation_note")
 	private String note;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "reservation_status", nullable = false, length = 20)
+	@Column(nullable = false, length = 20)
 	private ReservationStatus status;
 
 	@Builder
-	public ReservationEntity(Long userId, RestaurantSlotEntity slot, LocalDateTime visitAt, Integer partySize,
+	public ReservationEntity(Long userId, Long slotId, LocalDateTime visitAt, Integer partySize,
 		String note, ReservationStatus status) {
 		this.userId = userId;
-		this.slot = slot;
+		this.slotId = slotId;
 		this.visitAt = visitAt;
 		this.partySize = partySize;
 		this.note = note;
 		this.status = status;
-	}
-
-	public void assignSlot(RestaurantSlotEntity slot) {
-		this.slot = slot;
 	}
 }

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/mapper/ReservationMapper.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/mapper/ReservationMapper.java
@@ -1,0 +1,30 @@
+package com.reservation.tablereservationservice.infrastructure.reservation.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacity;
+import com.reservation.tablereservationservice.domain.reservation.Reservation;
+import com.reservation.tablereservationservice.global.config.MapstructConfig;
+import com.reservation.tablereservationservice.infrastructure.reservation.entity.DailySlotCapacityEntity;
+import com.reservation.tablereservationservice.infrastructure.reservation.entity.ReservationEntity;
+
+@Mapper(config = MapstructConfig.class)
+public interface ReservationMapper {
+
+	ReservationMapper INSTANCE = Mappers.getMapper(ReservationMapper.class);
+
+	@Mapping(target = "slotId", source = "slot.slotId")
+	DailySlotCapacity toDomain(DailySlotCapacityEntity entity);
+
+	@Mapping(target = "slot", ignore = true)
+	DailySlotCapacityEntity toEntity(DailySlotCapacity dailySlotCapacity);
+
+	@Mapping(target = "slotId", source = "slot.slotId")
+	Reservation toDomain(ReservationEntity entity);
+
+	@Mapping(target = "slot", ignore = true)
+	ReservationEntity toEntity(Reservation reservation);
+
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/mapper/ReservationMapper.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/mapper/ReservationMapper.java
@@ -1,7 +1,6 @@
 package com.reservation.tablereservationservice.infrastructure.reservation.mapper;
 
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacity;
@@ -15,16 +14,12 @@ public interface ReservationMapper {
 
 	ReservationMapper INSTANCE = Mappers.getMapper(ReservationMapper.class);
 
-	@Mapping(target = "slotId", source = "slot.slotId")
 	DailySlotCapacity toDomain(DailySlotCapacityEntity entity);
 
-	@Mapping(target = "slot", ignore = true)
 	DailySlotCapacityEntity toEntity(DailySlotCapacity dailySlotCapacity);
 
-	@Mapping(target = "slotId", source = "slot.slotId")
 	Reservation toDomain(ReservationEntity entity);
 
-	@Mapping(target = "slot", ignore = true)
 	ReservationEntity toEntity(Reservation reservation);
 
 }

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/DailySlotCapacityEntityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/DailySlotCapacityEntityRepository.java
@@ -9,6 +9,6 @@ import com.reservation.tablereservationservice.infrastructure.reservation.entity
 
 public interface DailySlotCapacityEntityRepository extends JpaRepository<DailySlotCapacityEntity, Long> {
 
-	Optional<DailySlotCapacityEntity> findBySlot_SlotIdAndDate(Long slotId, LocalDate date);
+	Optional<DailySlotCapacityEntity> findBySlotIdAndDate(Long slotSlotId, LocalDate date);
 
 }

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/DailySlotCapacityEntityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/DailySlotCapacityEntityRepository.java
@@ -1,0 +1,14 @@
+package com.reservation.tablereservationservice.infrastructure.reservation.repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.reservation.tablereservationservice.infrastructure.reservation.entity.DailySlotCapacityEntity;
+
+public interface DailySlotCapacityEntityRepository extends JpaRepository<DailySlotCapacityEntity, Long> {
+
+	Optional<DailySlotCapacityEntity> findBySlot_SlotIdAndDate(Long slotId, LocalDate date);
+
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaDailySlotCapacityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaDailySlotCapacityRepository.java
@@ -1,0 +1,53 @@
+package com.reservation.tablereservationservice.infrastructure.reservation.repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacity;
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacityRepository;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.ReservationException;
+import com.reservation.tablereservationservice.infrastructure.reservation.entity.DailySlotCapacityEntity;
+import com.reservation.tablereservationservice.infrastructure.reservation.mapper.ReservationMapper;
+import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantSlotEntity;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class JpaDailySlotCapacityRepository implements DailySlotCapacityRepository {
+
+	private final DailySlotCapacityEntityRepository dailySlotCapacityEntityRepository;
+	private final EntityManager em;
+
+	@Override
+	public Optional<DailySlotCapacity> findBySlotIdAndDate(Long slotId, LocalDate date) {
+		return dailySlotCapacityEntityRepository
+			.findBySlot_SlotIdAndDate(slotId, date)
+			.map(ReservationMapper.INSTANCE::toDomain);
+	}
+
+	@Override
+	public DailySlotCapacity save(DailySlotCapacity dailySlotCapacity) {
+		DailySlotCapacityEntity entity = ReservationMapper.INSTANCE.toEntity(dailySlotCapacity);
+
+		entity.assignSlot(em.getReference(RestaurantSlotEntity.class, dailySlotCapacity.getSlotId()));
+
+		DailySlotCapacityEntity saved = dailySlotCapacityEntityRepository.save(entity);
+		return ReservationMapper.INSTANCE.toDomain(saved);
+	}
+
+	@Override
+	public void update(DailySlotCapacity dailySlotCapacity) {
+		DailySlotCapacityEntity entity = dailySlotCapacityEntityRepository.findById(dailySlotCapacity.getCapacityId())
+			.orElseThrow(() -> new ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "DailySlotCapacity"));
+
+		entity.updateRemainingCount(dailySlotCapacity.getRemainingCount());
+
+		dailySlotCapacityEntityRepository.save(entity);
+	}
+
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaDailySlotCapacityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaDailySlotCapacityRepository.java
@@ -26,7 +26,7 @@ public class JpaDailySlotCapacityRepository implements DailySlotCapacityReposito
 	@Override
 	public Optional<DailySlotCapacity> findBySlotIdAndDate(Long slotId, LocalDate date) {
 		return dailySlotCapacityEntityRepository
-			.findBySlot_SlotIdAndDate(slotId, date)
+			.findBySlotIdAndDate(slotId, date)
 			.map(ReservationMapper.INSTANCE::toDomain);
 	}
 

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaDailySlotCapacityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaDailySlotCapacityRepository.java
@@ -11,9 +11,7 @@ import com.reservation.tablereservationservice.global.exception.ErrorCode;
 import com.reservation.tablereservationservice.global.exception.ReservationException;
 import com.reservation.tablereservationservice.infrastructure.reservation.entity.DailySlotCapacityEntity;
 import com.reservation.tablereservationservice.infrastructure.reservation.mapper.ReservationMapper;
-import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantSlotEntity;
 
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 
 @Repository
@@ -21,7 +19,6 @@ import lombok.RequiredArgsConstructor;
 public class JpaDailySlotCapacityRepository implements DailySlotCapacityRepository {
 
 	private final DailySlotCapacityEntityRepository dailySlotCapacityEntityRepository;
-	private final EntityManager em;
 
 	@Override
 	public Optional<DailySlotCapacity> findBySlotIdAndDate(Long slotId, LocalDate date) {
@@ -33,8 +30,6 @@ public class JpaDailySlotCapacityRepository implements DailySlotCapacityReposito
 	@Override
 	public DailySlotCapacity save(DailySlotCapacity dailySlotCapacity) {
 		DailySlotCapacityEntity entity = ReservationMapper.INSTANCE.toEntity(dailySlotCapacity);
-
-		entity.assignSlot(em.getReference(RestaurantSlotEntity.class, dailySlotCapacity.getSlotId()));
 
 		DailySlotCapacityEntity saved = dailySlotCapacityEntityRepository.save(entity);
 		return ReservationMapper.INSTANCE.toDomain(saved);

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaDailySlotCapacityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaDailySlotCapacityRepository.java
@@ -50,4 +50,9 @@ public class JpaDailySlotCapacityRepository implements DailySlotCapacityReposito
 		dailySlotCapacityEntityRepository.save(entity);
 	}
 
+	@Override
+	public void deleteAll() {
+		dailySlotCapacityEntityRepository.deleteAll();
+	}
+
 }

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaDailySlotCapacityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaDailySlotCapacityRepository.java
@@ -36,11 +36,11 @@ public class JpaDailySlotCapacityRepository implements DailySlotCapacityReposito
 	}
 
 	@Override
-	public void update(DailySlotCapacity dailySlotCapacity) {
-		DailySlotCapacityEntity entity = dailySlotCapacityEntityRepository.findById(dailySlotCapacity.getCapacityId())
+	public void updateRemainingCount(Long capacityId, Integer remainingCount) {
+		DailySlotCapacityEntity entity = dailySlotCapacityEntityRepository.findById(capacityId)
 			.orElseThrow(() -> new ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "DailySlotCapacity"));
 
-		entity.updateRemainingCount(dailySlotCapacity.getRemainingCount());
+		entity.updateRemainingCount(remainingCount);
 
 		dailySlotCapacityEntityRepository.save(entity);
 	}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaDailySlotCapacityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaDailySlotCapacityRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacity;
 import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacityRepository;
@@ -36,13 +37,14 @@ public class JpaDailySlotCapacityRepository implements DailySlotCapacityReposito
 	}
 
 	@Override
-	public void updateRemainingCount(Long capacityId, Integer remainingCount) {
-		DailySlotCapacityEntity entity = dailySlotCapacityEntityRepository.findById(capacityId)
+	@Transactional
+	public void updateRemainingCount(DailySlotCapacity capacity) {
+		DailySlotCapacityEntity entity = dailySlotCapacityEntityRepository.findById(capacity.getCapacityId())
 			.orElseThrow(() -> new ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "DailySlotCapacity"));
 
-		entity.updateRemainingCount(remainingCount);
+		entity.updateRemainingCount(capacity.getRemainingCount());
 
-		dailySlotCapacityEntityRepository.save(entity);
+		// save() 호출 없음 -> 영속성 컨텍스트 변경 감지로 UPDATE
 	}
 
 	@Override

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaReservationRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaReservationRepository.java
@@ -9,9 +9,7 @@ import com.reservation.tablereservationservice.domain.reservation.ReservationRep
 import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
 import com.reservation.tablereservationservice.infrastructure.reservation.entity.ReservationEntity;
 import com.reservation.tablereservationservice.infrastructure.reservation.mapper.ReservationMapper;
-import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantSlotEntity;
 
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 
 @Repository
@@ -19,13 +17,10 @@ import lombok.RequiredArgsConstructor;
 public class JpaReservationRepository implements ReservationRepository {
 
 	private final ReservationEntityRepository reservationEntityRepository;
-	private final EntityManager em;
 
 	@Override
 	public Reservation save(Reservation reservation) {
 		ReservationEntity entity = ReservationMapper.INSTANCE.toEntity(reservation);
-
-		entity.assignSlot(em.getReference(RestaurantSlotEntity.class, reservation.getSlotId()));
 
 		ReservationEntity saved = reservationEntityRepository.save(entity);
 		return ReservationMapper.INSTANCE.toDomain(saved);

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaReservationRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaReservationRepository.java
@@ -1,0 +1,39 @@
+package com.reservation.tablereservationservice.infrastructure.reservation.repository;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Repository;
+
+import com.reservation.tablereservationservice.domain.reservation.Reservation;
+import com.reservation.tablereservationservice.domain.reservation.ReservationRepository;
+import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
+import com.reservation.tablereservationservice.infrastructure.reservation.entity.ReservationEntity;
+import com.reservation.tablereservationservice.infrastructure.reservation.mapper.ReservationMapper;
+import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantSlotEntity;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class JpaReservationRepository implements ReservationRepository {
+
+	private final ReservationEntityRepository reservationEntityRepository;
+	private final EntityManager em;
+
+	@Override
+	public Reservation save(Reservation reservation) {
+		ReservationEntity entity = ReservationMapper.INSTANCE.toEntity(reservation);
+
+		entity.assignSlot(em.getReference(RestaurantSlotEntity.class, reservation.getSlotId()));
+
+		ReservationEntity saved = reservationEntityRepository.save(entity);
+		return ReservationMapper.INSTANCE.toDomain(saved);
+	}
+
+	@Override
+	public boolean existsByUserIdAndVisitAtAndStatus(Long userId, LocalDateTime visitAt,
+		ReservationStatus reservationStatus) {
+		return reservationEntityRepository.existsByUserIdAndVisitAtAndStatus(userId, visitAt, reservationStatus);
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaReservationRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaReservationRepository.java
@@ -36,4 +36,9 @@ public class JpaReservationRepository implements ReservationRepository {
 		ReservationStatus reservationStatus) {
 		return reservationEntityRepository.existsByUserIdAndVisitAtAndStatus(userId, visitAt, reservationStatus);
 	}
+
+	@Override
+	public void deleteAll() {
+		reservationEntityRepository.deleteAll();
+	}
 }

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/ReservationEntityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/ReservationEntityRepository.java
@@ -4,9 +4,10 @@ import java.time.LocalDateTime;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
 import com.reservation.tablereservationservice.infrastructure.reservation.entity.ReservationEntity;
 
 public interface ReservationEntityRepository extends JpaRepository<ReservationEntity, Long> {
 
-	boolean existsByUserIdAndVisitAt(Long userId, LocalDateTime visitAt);
+	boolean existsByUserIdAndVisitAtAndStatus(Long userId, LocalDateTime visitAt, ReservationStatus status);
 }

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/ReservationEntityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/ReservationEntityRepository.java
@@ -1,0 +1,12 @@
+package com.reservation.tablereservationservice.infrastructure.reservation.repository;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.reservation.tablereservationservice.infrastructure.reservation.entity.ReservationEntity;
+
+public interface ReservationEntityRepository extends JpaRepository<ReservationEntity, Long> {
+
+	boolean existsByUserIdAndVisitAt(Long userId, LocalDateTime visitAt);
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/entity/RestaurantEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/entity/RestaurantEntity.java
@@ -1,9 +1,13 @@
 package com.reservation.tablereservationservice.infrastructure.restaurant.entity;
 
+import com.reservation.tablereservationservice.domain.restaurant.CategoryCode;
+import com.reservation.tablereservationservice.domain.restaurant.RegionCode;
 import com.reservation.tablereservationservice.infrastructure.common.entity.BaseTimeEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,11 +29,13 @@ public class RestaurantEntity extends BaseTimeEntity {
 	@Column(name = "restaurant_owner_id", nullable = false)
 	private Long ownerId;
 
-	@Column(name = "restaurant_region_code_id", nullable = false, length = 10)
-	private String regionCodeId;
+	@Enumerated(EnumType.STRING)
+	@Column(name = "restaurant_region_code", nullable = false, length = 10)
+	private RegionCode regionCode;
 
-	@Column(name = "restaurant_category_code_id", nullable = false, length = 10)
-	private String categoryCodeId;
+	@Enumerated(EnumType.STRING)
+	@Column(name = "restaurant_category_code", nullable = false, length = 10)
+	private CategoryCode categoryCode;
 
 	@Column(name = "restaurant_name", nullable = false, length = 100)
 	private String name;
@@ -47,11 +53,11 @@ public class RestaurantEntity extends BaseTimeEntity {
 	private Integer mainMenuPrice;
 
 	@Builder
-	public RestaurantEntity(Long ownerId, String regionCodeId, String categoryCodeId, String name, String address,
+	public RestaurantEntity(Long ownerId, RegionCode regionCode, CategoryCode categoryCode, String name, String address,
 		String description, String mainMenuName, Integer mainMenuPrice) {
 		this.ownerId = ownerId;
-		this.regionCodeId = regionCodeId;
-		this.categoryCodeId = categoryCodeId;
+		this.regionCode = regionCode;
+		this.categoryCode = categoryCode;
 		this.name = name;
 		this.address = address;
 		this.description = description;

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/entity/RestaurantEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/entity/RestaurantEntity.java
@@ -26,30 +26,29 @@ public class RestaurantEntity extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long restaurantId;
 
-	@Column(name = "restaurant_owner_id", nullable = false)
+	@Column(nullable = false)
 	private Long ownerId;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "restaurant_region_code", nullable = false, length = 10)
+	@Column(nullable = false, length = 10)
 	private RegionCode regionCode;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "restaurant_category_code", nullable = false, length = 10)
+	@Column(nullable = false, length = 10)
 	private CategoryCode categoryCode;
 
-	@Column(name = "restaurant_name", nullable = false, length = 100)
+	@Column(nullable = false, length = 100)
 	private String name;
 
-	@Column(name = "restaurant_address", nullable = false)
+	@Column(nullable = false)
 	private String address;
 
-	@Column(name = "restaurant_description", columnDefinition = "TEXT")
+	@Column(columnDefinition = "TEXT")
 	private String description;
 
-	@Column(name = "restaurant_main_menu_name", length = 100)
+	@Column(length = 100)
 	private String mainMenuName;
 
-	@Column(name = "restaurant_main_menu_price")
 	private Integer mainMenuPrice;
 
 	@Builder

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/entity/RestaurantEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/entity/RestaurantEntity.java
@@ -1,0 +1,61 @@
+package com.reservation.tablereservationservice.infrastructure.restaurant.entity;
+
+import com.reservation.tablereservationservice.infrastructure.common.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "restaurant")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class RestaurantEntity extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long restaurantId;
+
+	@Column(name = "restaurant_owner_id", nullable = false)
+	private Long ownerId;
+
+	@Column(name = "restaurant_region_code_id", nullable = false, length = 10)
+	private String regionCodeId;
+
+	@Column(name = "restaurant_category_code_id", nullable = false, length = 10)
+	private String categoryCodeId;
+
+	@Column(name = "restaurant_name", nullable = false, length = 100)
+	private String name;
+
+	@Column(name = "restaurant_address", nullable = false)
+	private String address;
+
+	@Column(name = "restaurant_description", columnDefinition = "TEXT")
+	private String description;
+
+	@Column(name = "restaurant_main_menu_name", length = 100)
+	private String mainMenuName;
+
+	@Column(name = "restaurant_main_menu_price")
+	private Integer mainMenuPrice;
+
+	@Builder
+	public RestaurantEntity(Long ownerId, String regionCodeId, String categoryCodeId, String name, String address,
+		String description, String mainMenuName, Integer mainMenuPrice) {
+		this.ownerId = ownerId;
+		this.regionCodeId = regionCodeId;
+		this.categoryCodeId = categoryCodeId;
+		this.name = name;
+		this.address = address;
+		this.description = description;
+		this.mainMenuName = mainMenuName;
+		this.mainMenuPrice = mainMenuPrice;
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/entity/RestaurantSlotEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/entity/RestaurantSlotEntity.java
@@ -1,0 +1,47 @@
+package com.reservation.tablereservationservice.infrastructure.restaurant.entity;
+
+import java.time.LocalTime;
+
+import com.reservation.tablereservationservice.infrastructure.common.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "restaurant_slot")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class RestaurantSlotEntity extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "restaurant_slot_id")
+	private Long slotId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "restaurant_slot_restaurant_id", nullable = false)
+	private RestaurantEntity restaurant;
+
+	@Column(name = "restaurant_slot_time", nullable = false)
+	private LocalTime time;
+
+	@Column(name = "restaurant_slot_max_capacity", nullable = false)
+	private Integer maxCapacity;
+
+	@Builder
+	public RestaurantSlotEntity(RestaurantEntity restaurant, LocalTime time, Integer maxCapacity) {
+		this.restaurant = restaurant;
+		this.time = time;
+		this.maxCapacity = maxCapacity;
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/entity/RestaurantSlotEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/entity/RestaurantSlotEntity.java
@@ -6,12 +6,9 @@ import com.reservation.tablereservationservice.infrastructure.common.entity.Base
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.Builder;
@@ -20,36 +17,36 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "restaurant_slot",
+@Table(
+	name = "restaurant_slot",
 	uniqueConstraints = {
-		@UniqueConstraint(name = "uq_restaurant_time", columnNames = {"restaurant_slot_restaurant_id", "restaurant_slot_time"})
-	})
+		@UniqueConstraint(
+			name = "uq_restaurant_time",
+			columnNames = {"restaurant_id", "time"}
+		)
+	}
+)
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class RestaurantSlotEntity extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "restaurant_slot_id")
 	private Long slotId;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "restaurant_slot_restaurant_id", nullable = false)
-	private RestaurantEntity restaurant;
+	@Column(nullable = false)
+	private Long restaurantId;
 
-	@Column(name = "restaurant_slot_time", nullable = false)
+	@Column(nullable = false)
 	private LocalTime time;
 
-	@Column(name = "restaurant_slot_max_capacity", nullable = false)
+	@Column(nullable = false)
 	private Integer maxCapacity;
 
 	@Builder
-	public RestaurantSlotEntity(RestaurantEntity restaurant, LocalTime time, Integer maxCapacity) {
-		this.restaurant = restaurant;
+	public RestaurantSlotEntity(Long restaurantId, LocalTime time, Integer maxCapacity) {
+		this.restaurantId = restaurantId;
 		this.time = time;
 		this.maxCapacity = maxCapacity;
 	}
 
-	public void assignRestaurant(RestaurantEntity restaurant) {
-		this.restaurant = restaurant;
-	}
 }

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/entity/RestaurantSlotEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/entity/RestaurantSlotEntity.java
@@ -13,13 +13,17 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "restaurant_slot")
+@Table(name = "restaurant_slot",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uq_restaurant_time", columnNames = {"restaurant_slot_restaurant_id", "restaurant_slot_time"})
+	})
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class RestaurantSlotEntity extends BaseTimeEntity {
 
@@ -43,5 +47,9 @@ public class RestaurantSlotEntity extends BaseTimeEntity {
 		this.restaurant = restaurant;
 		this.time = time;
 		this.maxCapacity = maxCapacity;
+	}
+
+	public void assignRestaurant(RestaurantEntity restaurant) {
+		this.restaurant = restaurant;
 	}
 }

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/mapper/RestaurantMapper.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/mapper/RestaurantMapper.java
@@ -1,0 +1,28 @@
+package com.reservation.tablereservationservice.infrastructure.restaurant.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+import com.reservation.tablereservationservice.domain.restaurant.Restaurant;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlot;
+import com.reservation.tablereservationservice.global.config.MapstructConfig;
+import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantEntity;
+import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantSlotEntity;
+
+@Mapper(config = MapstructConfig.class)
+public interface RestaurantMapper {
+
+	RestaurantMapper INSTANCE = Mappers.getMapper(RestaurantMapper.class);
+
+	Restaurant toDomain(RestaurantEntity entity);
+
+	RestaurantEntity toEntity(Restaurant restaurant);
+
+	@Mapping(target = "restaurantId", source = "restaurant.restaurantId")
+	RestaurantSlot toDomain(RestaurantSlotEntity entity);
+
+	@Mapping(target = "restaurant", ignore = true)
+	RestaurantSlotEntity toEntity(RestaurantSlot restaurantSlot);
+
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/mapper/RestaurantMapper.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/mapper/RestaurantMapper.java
@@ -19,10 +19,8 @@ public interface RestaurantMapper {
 
 	RestaurantEntity toEntity(Restaurant restaurant);
 
-	@Mapping(target = "restaurantId", source = "restaurant.restaurantId")
 	RestaurantSlot toDomain(RestaurantSlotEntity entity);
 
-	@Mapping(target = "restaurant", ignore = true)
 	RestaurantSlotEntity toEntity(RestaurantSlot restaurantSlot);
 
 }

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/repository/JpaRestaurantRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/repository/JpaRestaurantRepository.java
@@ -1,0 +1,33 @@
+package com.reservation.tablereservationservice.infrastructure.restaurant.repository;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.reservation.tablereservationservice.domain.restaurant.Restaurant;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantRepository;
+import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantEntity;
+import com.reservation.tablereservationservice.infrastructure.restaurant.mapper.RestaurantMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class JpaRestaurantRepository implements RestaurantRepository {
+
+	private final RestaurantEntityRepository restaurantEntityRepository;
+
+	@Override
+	public Optional<Restaurant> findById(Long restaurantId) {
+		return restaurantEntityRepository.findById(restaurantId)
+			.map(RestaurantMapper.INSTANCE::toDomain);
+	}
+
+	@Override
+	public Restaurant save(Restaurant restaurant) {
+		RestaurantEntity entity = RestaurantMapper.INSTANCE.toEntity(restaurant);
+		RestaurantEntity saved = restaurantEntityRepository.save(entity);
+
+		return RestaurantMapper.INSTANCE.toDomain(saved);
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/repository/JpaRestaurantRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/repository/JpaRestaurantRepository.java
@@ -30,4 +30,9 @@ public class JpaRestaurantRepository implements RestaurantRepository {
 
 		return RestaurantMapper.INSTANCE.toDomain(saved);
 	}
+
+	@Override
+	public void deleteAll() {
+		restaurantEntityRepository.deleteAll();
+	}
 }

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/repository/JpaRestaurantSlotRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/repository/JpaRestaurantSlotRepository.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Repository;
 
 import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlot;
 import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlotRepository;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.RestaurantException;
 import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantEntity;
 import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantSlotEntity;
 import com.reservation.tablereservationservice.infrastructure.restaurant.mapper.RestaurantMapper;
@@ -35,6 +37,12 @@ public class JpaRestaurantSlotRepository implements RestaurantSlotRepository {
 		RestaurantSlotEntity saved = restaurantSlotEntityRepository.save(entity);
 		return RestaurantMapper.INSTANCE.toDomain(saved);
 
+	}
+
+	@Override
+	public RestaurantSlot fetchById(Long slotId) {
+		return findById(slotId)
+			.orElseThrow(() -> new RestaurantException(ErrorCode.RESOURCE_NOT_FOUND, "Restaurant"));
 	}
 
 	@Override

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/repository/JpaRestaurantSlotRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/repository/JpaRestaurantSlotRepository.java
@@ -1,0 +1,39 @@
+package com.reservation.tablereservationservice.infrastructure.restaurant.repository;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlot;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlotRepository;
+import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantEntity;
+import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantSlotEntity;
+import com.reservation.tablereservationservice.infrastructure.restaurant.mapper.RestaurantMapper;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class JpaRestaurantSlotRepository implements RestaurantSlotRepository {
+
+	private final RestaurantSlotEntityRepository restaurantSlotEntityRepository;
+	private final EntityManager em;
+
+	@Override
+	public Optional<RestaurantSlot> findById(Long slotId) {
+		return restaurantSlotEntityRepository.findById(slotId)
+			.map(RestaurantMapper.INSTANCE::toDomain);
+	}
+
+	@Override
+	public RestaurantSlot save(RestaurantSlot restaurantSlot) {
+		RestaurantSlotEntity entity = RestaurantMapper.INSTANCE.toEntity(restaurantSlot);
+
+		entity.assignRestaurant(em.getReference(RestaurantEntity.class, restaurantSlot.getRestaurantId()));
+
+		RestaurantSlotEntity saved = restaurantSlotEntityRepository.save(entity);
+		return RestaurantMapper.INSTANCE.toDomain(saved);
+
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/repository/JpaRestaurantSlotRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/repository/JpaRestaurantSlotRepository.java
@@ -8,11 +8,9 @@ import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlot;
 import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlotRepository;
 import com.reservation.tablereservationservice.global.exception.ErrorCode;
 import com.reservation.tablereservationservice.global.exception.RestaurantException;
-import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantEntity;
 import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantSlotEntity;
 import com.reservation.tablereservationservice.infrastructure.restaurant.mapper.RestaurantMapper;
 
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 
 @Repository
@@ -20,7 +18,6 @@ import lombok.RequiredArgsConstructor;
 public class JpaRestaurantSlotRepository implements RestaurantSlotRepository {
 
 	private final RestaurantSlotEntityRepository restaurantSlotEntityRepository;
-	private final EntityManager em;
 
 	@Override
 	public Optional<RestaurantSlot> findById(Long slotId) {
@@ -31,8 +28,6 @@ public class JpaRestaurantSlotRepository implements RestaurantSlotRepository {
 	@Override
 	public RestaurantSlot save(RestaurantSlot restaurantSlot) {
 		RestaurantSlotEntity entity = RestaurantMapper.INSTANCE.toEntity(restaurantSlot);
-
-		entity.assignRestaurant(em.getReference(RestaurantEntity.class, restaurantSlot.getRestaurantId()));
 
 		RestaurantSlotEntity saved = restaurantSlotEntityRepository.save(entity);
 		return RestaurantMapper.INSTANCE.toDomain(saved);

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/repository/JpaRestaurantSlotRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/repository/JpaRestaurantSlotRepository.java
@@ -36,4 +36,9 @@ public class JpaRestaurantSlotRepository implements RestaurantSlotRepository {
 		return RestaurantMapper.INSTANCE.toDomain(saved);
 
 	}
+
+	@Override
+	public void deleteAll() {
+		restaurantSlotEntityRepository.deleteAll();
+	}
 }

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/repository/RestaurantEntityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/repository/RestaurantEntityRepository.java
@@ -1,0 +1,12 @@
+package com.reservation.tablereservationservice.infrastructure.restaurant.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantEntity;
+
+public interface RestaurantEntityRepository extends JpaRepository<RestaurantEntity, Long> {
+
+	Optional<RestaurantEntity> findById(Long restaurantId);
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/repository/RestaurantSlotEntityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/restaurant/repository/RestaurantSlotEntityRepository.java
@@ -1,0 +1,9 @@
+package com.reservation.tablereservationservice.infrastructure.restaurant.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.reservation.tablereservationservice.infrastructure.restaurant.entity.RestaurantSlotEntity;
+
+public interface RestaurantSlotEntityRepository extends JpaRepository<RestaurantSlotEntity, Long> {
+
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/user/repository/JpaUserRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/user/repository/JpaUserRepository.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Repository;
 
 import com.reservation.tablereservationservice.domain.user.User;
 import com.reservation.tablereservationservice.domain.user.UserRepository;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.UserException;
 import com.reservation.tablereservationservice.infrastructure.user.entity.UserEntity;
 import com.reservation.tablereservationservice.infrastructure.user.mapper.UserMapper;
 
@@ -40,6 +42,12 @@ public class JpaUserRepository implements UserRepository {
 	public Optional<User> findByEmail(String email) {
 		return userEntityRepository.findByEmail(email)
 			.map(UserMapper.INSTANCE::toDomain);
+	}
+
+	@Override
+	public User fetchByEmail(String email) {
+		return findByEmail(email)
+			.orElseThrow(() -> new UserException(ErrorCode.RESOURCE_NOT_FOUND, "User"));
 	}
 
 	@Override

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/user/repository/UserEntityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/user/repository/UserEntityRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.reservation.tablereservationservice.infrastructure.user.entity.UserEntity;
 
-interface UserEntityRepository extends JpaRepository<UserEntity, Long> {
+public interface UserEntityRepository extends JpaRepository<UserEntity, Long> {
 
 	boolean existsByEmail(String email);
 

--- a/src/main/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationController.java
+++ b/src/main/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationController.java
@@ -1,0 +1,37 @@
+package com.reservation.tablereservationservice.presentation.reservation.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.reservation.tablereservationservice.application.reservation.service.ReservationService;
+import com.reservation.tablereservationservice.domain.reservation.Reservation;
+import com.reservation.tablereservationservice.presentation.common.ApiResponse;
+import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationRequestDto;
+import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationResponseDto;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reservations")
+public class ReservationController {
+
+	private final ReservationService reservationService;
+
+	@PreAuthorize("hasRole('CUSTOMER')")
+	@PostMapping
+	public ApiResponse<ReservationResponseDto> create(@Valid @RequestBody ReservationRequestDto requestDto,
+		Authentication authentication) {
+		String email = (String)authentication.getPrincipal();
+		Reservation reservation = reservationService.create(email, requestDto);
+		ReservationResponseDto responseDto = ReservationResponseDto.from(reservation);
+
+		return ApiResponse.success("예약 요청 성공", responseDto);
+	}
+
+}

--- a/src/main/java/com/reservation/tablereservationservice/presentation/reservation/dto/ReservationRequestDto.java
+++ b/src/main/java/com/reservation/tablereservationservice/presentation/reservation/dto/ReservationRequestDto.java
@@ -2,6 +2,9 @@ package com.reservation.tablereservationservice.presentation.reservation.dto;
 
 import java.time.LocalDate;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,8 +12,15 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ReservationRequestDto {
 
+	@NotNull(message = "slotId는 필수입니다.")
 	private Long slotId;
+
+	@NotNull(message = "예약 날짜는 필수입니다.")
 	private LocalDate date;
+
+	@Min(value = 1, message = "예약 인원은 1명 이상이어야 합니다.")
 	private int partySize;
+
+	@Size(max = 200, message = "요청 사항은 최대 200자까지 가능합니다.")
 	private String note;
 }

--- a/src/main/java/com/reservation/tablereservationservice/presentation/reservation/dto/ReservationRequestDto.java
+++ b/src/main/java/com/reservation/tablereservationservice/presentation/reservation/dto/ReservationRequestDto.java
@@ -1,0 +1,16 @@
+package com.reservation.tablereservationservice.presentation.reservation.dto;
+
+import java.time.LocalDate;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReservationRequestDto {
+
+	private Long slotId;
+	private LocalDate date;
+	private int partySize;
+	private String note;
+}

--- a/src/main/java/com/reservation/tablereservationservice/presentation/reservation/dto/ReservationResponseDto.java
+++ b/src/main/java/com/reservation/tablereservationservice/presentation/reservation/dto/ReservationResponseDto.java
@@ -1,0 +1,35 @@
+package com.reservation.tablereservationservice.presentation.reservation.dto;
+
+import java.time.LocalDateTime;
+
+import com.reservation.tablereservationservice.domain.reservation.Reservation;
+import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ReservationResponseDto {
+
+	private Long reservationId;
+	private Integer partySize;
+	private ReservationStatus status;
+	private LocalDateTime visitAt;
+
+	@Builder
+	public ReservationResponseDto(Long reservationId, Integer partySize, ReservationStatus status, LocalDateTime visitAt) {
+		this.reservationId = reservationId;
+		this.partySize = partySize;
+		this.status = status;
+		this.visitAt = visitAt;
+	}
+
+	public static ReservationResponseDto from(Reservation reservation) {
+		return ReservationResponseDto.builder()
+			.reservationId(reservation.getReservationId())
+			.partySize(reservation.getPartySize())
+			.status(reservation.getStatus())
+			.visitAt(reservation.getVisitAt())
+			.build();
+	}
+}

--- a/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceIntegrationTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceIntegrationTest.java
@@ -110,7 +110,7 @@ class ReservationServiceIntegrationTest {
 	void create_success_confirmed_and_decreaseCapacity() {
 		// given
 		int partySize = 2;
-		saveCapacity(slotId, date, 10, 10);
+		saveCapacity(slotId, date, 10);
 
 		ReservationRequestDto req = new ReservationRequestDto(slotId, date, partySize, "note");
 		LocalDateTime visitAt = LocalDateTime.of(date, slotTime);
@@ -144,7 +144,7 @@ class ReservationServiceIntegrationTest {
 	void create_fail_duplicatedTime_preCheck() {
 		// given
 		// 첫 번째 예약
-		saveCapacity(slotId, date, 10, 10);
+		saveCapacity(slotId, date, 10);
 		reservationService.create(email, new ReservationRequestDto(slotId, date, 2, ""));
 
 		// when & then
@@ -169,7 +169,6 @@ class ReservationServiceIntegrationTest {
 			.slotId(slotId)
 			.date(date)
 			.remainingCount(1) // remainingCount를 1로 만들어서 준비
-			.maxCount(10)
 			.version(0L)
 			.build();
 		dailySlotCapacityRepository.save(capacity);
@@ -207,12 +206,11 @@ class ReservationServiceIntegrationTest {
 			});
 	}
 
-	private void saveCapacity(Long slotId, LocalDate date, int remainingCount, int maxCount) {
+	private void saveCapacity(Long slotId, LocalDate date, int remainingCount) {
 		DailySlotCapacity capacity = DailySlotCapacity.builder()
 			.slotId(slotId)
 			.date(date)
 			.remainingCount(remainingCount)
-			.maxCount(maxCount)
 			.version(0L)
 			.build();
 

--- a/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceIntegrationTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceIntegrationTest.java
@@ -1,0 +1,221 @@
+package com.reservation.tablereservationservice.application.reservation.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacity;
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacityRepository;
+import com.reservation.tablereservationservice.domain.reservation.Reservation;
+import com.reservation.tablereservationservice.domain.reservation.ReservationRepository;
+import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
+import com.reservation.tablereservationservice.domain.restaurant.CategoryCode;
+import com.reservation.tablereservationservice.domain.restaurant.RegionCode;
+import com.reservation.tablereservationservice.domain.restaurant.Restaurant;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantRepository;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlot;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlotRepository;
+import com.reservation.tablereservationservice.domain.user.User;
+import com.reservation.tablereservationservice.domain.user.UserRepository;
+import com.reservation.tablereservationservice.domain.user.UserRole;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.ReservationException;
+import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationRequestDto;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class ReservationServiceIntegrationTest {
+
+	@Autowired
+	private ReservationService reservationService;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private RestaurantRepository restaurantRepository;
+
+	@Autowired
+	private RestaurantSlotRepository restaurantSlotRepository;
+
+	@Autowired
+	private DailySlotCapacityRepository dailySlotCapacityRepository;
+
+	@Autowired
+	private ReservationRepository reservationRepository;
+
+	private String email;
+	private Long userId;
+	private Long slotId;
+	private LocalDate date;
+	private LocalTime slotTime;
+
+	@BeforeEach
+	void setUp() {
+		this.email = "customer01@test.com";
+		this.date = LocalDate.now();
+		this.slotTime = LocalTime.of(19, 0);
+
+		User customer = User.builder()
+			.email(email)
+			.name("customer01")
+			.phone("010-0000-0000")
+			.password("encrypted-password")
+			.userRole(UserRole.CUSTOMER)
+			.build();
+		User savedCustomer = userRepository.save(customer);
+
+		User owner = User.builder()
+			.email("owner@test.com")
+			.name("owner")
+			.phone("010-0000-0001")
+			.password("encrypted-password")
+			.userRole(UserRole.OWNER)
+			.build();
+		User savedOwner = userRepository.save(owner);
+
+		Restaurant restaurant = Restaurant.builder()
+			.name("강남 한상")
+			.regionCode(RegionCode.RG01)
+			.categoryCode(CategoryCode.CT01)
+			.address("서울 강남구 테헤란로 1")
+			.ownerId(savedOwner.getUserId())
+			.build();
+		Restaurant savedRestaurant = restaurantRepository.save(restaurant);
+
+		RestaurantSlot restaurantSlot = RestaurantSlot.builder()
+			.restaurantId(savedRestaurant.getRestaurantId())
+			.time(slotTime)
+			.maxCapacity(10)
+			.build();
+		RestaurantSlot savedRestaurantSlot = restaurantSlotRepository.save(restaurantSlot);
+
+		this.userId = savedCustomer.getUserId();
+		this.slotId = savedRestaurantSlot.getSlotId();
+	}
+
+	@Test
+	@DisplayName("예약 생성 성공 - CONFIRMED 저장 + capacity 차감")
+	void create_success_confirmed_and_decreaseCapacity() {
+		// given
+		int partySize = 2;
+		saveCapacity(slotId, date, 10, 10);
+
+		ReservationRequestDto req = new ReservationRequestDto(slotId, date, partySize, "note");
+		LocalDateTime visitAt = LocalDateTime.of(date, slotTime);
+
+		DailySlotCapacity before = dailySlotCapacityRepository.findBySlotIdAndDate(slotId, date)
+			.orElseThrow(() -> new IllegalStateException("DailySlotCapacity not found"));
+		assertThat(before.getRemainingCount()).isEqualTo(10);
+
+		// when
+		Reservation saved = reservationService.create(email, req);
+
+		// then
+		assertThat(saved.getReservationId()).isNotNull();
+		assertThat(saved.getUserId()).isEqualTo(userId);
+		assertThat(saved.getSlotId()).isEqualTo(slotId);
+		assertThat(saved.getVisitAt()).isEqualTo(visitAt);
+		assertThat(saved.getPartySize()).isEqualTo(partySize);
+		assertThat(saved.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+
+		DailySlotCapacity after = dailySlotCapacityRepository.findBySlotIdAndDate(slotId, date)
+			.orElseThrow(() -> new IllegalStateException("DailySlotCapacity not found"));
+		assertThat(after.getRemainingCount()).isEqualTo(8);
+
+		// 저장된 예약이 실제로 CONFIRMED로 존재하는지
+		assertThat(reservationRepository.existsByUserIdAndVisitAtAndStatus(userId, visitAt,
+			ReservationStatus.CONFIRMED)).isTrue();
+	}
+
+	@Test
+	@DisplayName("중복 예약 실패")
+	void create_fail_duplicatedTime_preCheck() {
+		// given
+		// 첫 번째 예약
+		saveCapacity(slotId, date, 10, 10);
+		reservationService.create(email, new ReservationRequestDto(slotId, date, 2, ""));
+
+		// when & then
+		// 동일한 조건으로 다시 예약 (동일 유저, 같은 날짜)
+		assertThatThrownBy(() -> reservationService.create(email, new ReservationRequestDto(slotId, date, 2, "")))
+			.isInstanceOf(ReservationException.class)
+			.satisfies(ex -> {
+				ReservationException re = (ReservationException)ex;
+				assertThat(re.getErrorCode()).isEqualTo(ErrorCode.RESERVATION_DUPLICATED_TIME);
+			});
+
+		DailySlotCapacity after = dailySlotCapacityRepository.findBySlotIdAndDate(slotId, date)
+			.orElseThrow(() -> new IllegalStateException("DailySlotCapacity not found"));
+		assertThat(after.getRemainingCount()).isEqualTo(8); // 첫 번째 예약에서만 2명이 차감된다.
+	}
+
+	@Test
+	@DisplayName("좌석 부족 실패")
+	void create_fail_capacityNotEnough() {
+		// given
+		DailySlotCapacity capacity = DailySlotCapacity.builder()
+			.slotId(slotId)
+			.date(date)
+			.remainingCount(1) // remainingCount를 1로 만들어서 준비
+			.maxCount(10)
+			.version(0L)
+			.build();
+		dailySlotCapacityRepository.save(capacity);
+
+		int partySize = 5; // 실제 요청은 5
+
+		// when & then
+		assertThatThrownBy(
+			() -> reservationService.create(email, new ReservationRequestDto(slotId, date, partySize, "")))
+			.isInstanceOf(ReservationException.class)
+			.satisfies(ex -> {
+				ReservationException re = (ReservationException)ex;
+				assertThat(re.getErrorCode()).isEqualTo(ErrorCode.RESERVATION_CAPACITY_NOT_ENOUGH);
+			});
+
+		// 실패면 예약 저장이 없어야 하고, capacity는 그대로(1)여야 함
+		DailySlotCapacity after = dailySlotCapacityRepository.findBySlotIdAndDate(slotId, date)
+			.orElseThrow(() -> new IllegalStateException("DailySlotCapacity not found"));
+		assertThat(after.getRemainingCount()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("슬롯 미오픈 실패 - capacity row 없음 (RESERVATION_SLOT_NOT_OPENED)")
+	void create_fail_slotNotOpened() {
+		// given
+		// capacity를 저장하지 않는다 = 미오픈 상태
+		ReservationRequestDto req = new ReservationRequestDto(slotId, date, 2, "");
+
+		// when & then
+		assertThatThrownBy(() -> reservationService.create(email, req))
+			.isInstanceOf(ReservationException.class)
+			.satisfies(ex -> {
+				ReservationException re = (ReservationException)ex;
+				assertThat(re.getErrorCode()).isEqualTo(ErrorCode.RESERVATION_SLOT_NOT_OPENED);
+			});
+	}
+
+	private void saveCapacity(Long slotId, LocalDate date, int remainingCount, int maxCount) {
+		DailySlotCapacity capacity = DailySlotCapacity.builder()
+			.slotId(slotId)
+			.date(date)
+			.remainingCount(remainingCount)
+			.maxCount(maxCount)
+			.version(0L)
+			.build();
+
+		dailySlotCapacityRepository.save(capacity);
+	}
+}

--- a/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceTest.java
@@ -87,7 +87,6 @@ class ReservationServiceTest {
 				.reservationId(999L)
 				.userId(r.getUserId())
 				.slotId(r.getSlotId())
-				.date(r.getDate())
 				.visitAt(r.getVisitAt())
 				.partySize(r.getPartySize())
 				.note(r.getNote())

--- a/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceTest.java
@@ -105,8 +105,14 @@ class ReservationServiceTest {
 		assertThat(saved.getPartySize()).isEqualTo(partySize);
 		assertThat(saved.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
 
-		verify(dailySlotCapacityRepository, times(1)).updateRemainingCount(eq(777L), eq(8));
-	}
+		ArgumentCaptor<DailySlotCapacity> captor = ArgumentCaptor.forClass(DailySlotCapacity.class);
+		verify(dailySlotCapacityRepository, times(1)).updateRemainingCount(captor.capture());
+
+		DailySlotCapacity updated = captor.getValue();
+		assertThat(updated.getCapacityId()).isEqualTo(777L);
+		assertThat(updated.getSlotId()).isEqualTo(slotId);
+		assertThat(updated.getDate()).isEqualTo(date);
+		assertThat(updated.getRemainingCount()).isEqualTo(8);	}
 
 	@Test
 	@DisplayName("실패 - 유저 없음")
@@ -183,7 +189,7 @@ class ReservationServiceTest {
 				.isEqualTo(ErrorCode.RESERVATION_SLOT_NOT_OPENED));
 
 		verify(reservationRepository, never()).save(any());
-		verify(dailySlotCapacityRepository, never()).updateRemainingCount(anyLong(), anyInt());
+		verify(dailySlotCapacityRepository, never()).updateRemainingCount(any(DailySlotCapacity.class));
 	}
 
 	@Test
@@ -222,7 +228,7 @@ class ReservationServiceTest {
 				.isEqualTo(ErrorCode.RESERVATION_CAPACITY_NOT_ENOUGH));
 
 		verify(reservationRepository, never()).save(any());
-		verify(dailySlotCapacityRepository, never()).updateRemainingCount(anyLong(), anyInt());
+		verify(dailySlotCapacityRepository, never()).updateRemainingCount(any(DailySlotCapacity.class));
 	}
 
 	@Test

--- a/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceTest.java
@@ -1,0 +1,238 @@
+package com.reservation.tablereservationservice.application.reservation.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacity;
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacityRepository;
+import com.reservation.tablereservationservice.domain.reservation.Reservation;
+import com.reservation.tablereservationservice.domain.reservation.ReservationRepository;
+import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlot;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlotRepository;
+import com.reservation.tablereservationservice.domain.user.User;
+import com.reservation.tablereservationservice.domain.user.UserRepository;
+import com.reservation.tablereservationservice.domain.user.UserRole;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.ReservationException;
+import com.reservation.tablereservationservice.global.exception.UserException;
+import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationRequestDto;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceTest {
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private RestaurantSlotRepository restaurantSlotRepository;
+
+	@Mock
+	private DailySlotCapacityRepository dailySlotCapacityRepository;
+
+	@Mock
+	private ReservationRepository reservationRepository;
+
+	@InjectMocks
+	private ReservationService reservationService;
+
+	@Test
+	@DisplayName("예약 생성 성공 - CONFIRMED 저장 + capacity 차감")
+	void create_success() {
+		// given
+		String email = "customer01@test.com";
+		LocalDate date = LocalDate.of(2026, 1, 26);
+		LocalTime slotTime = LocalTime.of(19, 0);
+		Long userId = 1L;
+		Long slotId = 10L;
+		Long restaurantId = 100L;
+		int partySize = 2;
+
+		User user = createTestUser(userId, email);
+		RestaurantSlot slot = createTestSlot(slotId, restaurantId, slotTime);
+
+		DailySlotCapacity capacity = DailySlotCapacity.builder()
+			.capacityId(777L)
+			.slotId(slotId)
+			.date(date)
+			.remainingCount(10)
+			.maxCount(10)
+			.version(0L)
+			.build();
+
+		ReservationRequestDto req = new ReservationRequestDto(slotId, date, partySize, "note");
+
+		given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+		given(restaurantSlotRepository.findById(slotId)).willReturn(Optional.of(slot));
+		given(reservationRepository.existsByUserIdAndVisitAtAndStatus(userId, LocalDateTime.of(date, slotTime),
+			ReservationStatus.CONFIRMED)).willReturn(false);
+		given(dailySlotCapacityRepository.findBySlotIdAndDate(slotId, date)).willReturn(Optional.of(capacity));
+		given(reservationRepository.save(any(Reservation.class))).willAnswer(inv -> {
+			Reservation r = inv.getArgument(0);
+			return Reservation.builder()
+				.reservationId(999L)
+				.userId(r.getUserId())
+				.slotId(r.getSlotId())
+				.date(r.getDate())
+				.visitAt(r.getVisitAt())
+				.partySize(r.getPartySize())
+				.note(r.getNote())
+				.status(r.getStatus())
+				.build();
+		});
+
+		// when
+		Reservation saved = reservationService.create(email, req);
+
+		// then
+		assertThat(saved.getReservationId()).isEqualTo(999L);
+		assertThat(saved.getUserId()).isEqualTo(userId);
+		assertThat(saved.getSlotId()).isEqualTo(slotId);
+		assertThat(saved.getVisitAt()).isEqualTo(LocalDateTime.of(date, slotTime));
+		assertThat(saved.getPartySize()).isEqualTo(partySize);
+		assertThat(saved.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+
+		// capacity update 호출 + 차감 값 검증
+		ArgumentCaptor<DailySlotCapacity> capacityCaptor = ArgumentCaptor.forClass(DailySlotCapacity.class);
+		verify(dailySlotCapacityRepository, times(1)).update(capacityCaptor.capture());
+		assertThat(capacityCaptor.getValue().getRemainingCount()).isEqualTo(8);
+
+	}
+
+	@Test
+	@DisplayName("실패 - 유저 없음")
+	void create_fail_userNotFound() {
+		// given
+		String email = "customer01@test.com";
+		ReservationRequestDto req = new ReservationRequestDto(1L, LocalDate.of(2026, 1, 26), 2, "");
+
+		given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> reservationService.create(email, req))
+			.isInstanceOf(UserException.class);
+	}
+
+	@Test
+	@DisplayName("실패 - 중복 예약 예외 발생")
+	void create_fail_duplicatedTime_preCheck() {
+		// given
+		String email = "customer01@test.com";
+		Long userId = 1L;
+		Long slotId = 10L;
+		Long restaurantId = 100L;
+		LocalDate date = LocalDate.of(2026, 1, 26);
+		LocalTime slotTime = LocalTime.of(19, 0);
+
+		given(userRepository.findByEmail(email)).willReturn(Optional.of(createTestUser(userId, email)));
+		given(restaurantSlotRepository.findById(slotId)).willReturn(
+			Optional.of(createTestSlot(slotId, restaurantId, slotTime)));
+		given(reservationRepository.existsByUserIdAndVisitAtAndStatus(userId, LocalDateTime.of(date, slotTime),
+			ReservationStatus.CONFIRMED)).willReturn(true);
+
+		// when & then
+		assertThatThrownBy(() -> reservationService.create(email, new ReservationRequestDto(slotId, date, 2, "")))
+			.isInstanceOf(ReservationException.class)
+			.satisfies(ex -> {
+				ReservationException re = (ReservationException)ex;
+				assertThat(re.getErrorCode()).isEqualTo(ErrorCode.RESERVATION_DUPLICATED_TIME);
+			});
+	}
+
+	@Test
+	@DisplayName("실패 - capacity row 없음(해당 날짜 슬롯 미오픈)")
+	void create_fail_slotNotOpened() {
+		// given
+		String email = "customer01@test.com";
+		Long userId = 1L;
+		Long slotId = 10L;
+		Long restaurantId = 100L;
+		LocalDate date = LocalDate.of(2026, 1, 26);
+		LocalTime slotTime = LocalTime.of(19, 0);
+
+		given(userRepository.findByEmail(email)).willReturn(Optional.of(createTestUser(userId, email)));
+		given(restaurantSlotRepository.findById(slotId)).willReturn(
+			Optional.of(createTestSlot(slotId, restaurantId, slotTime)));
+		given(reservationRepository.existsByUserIdAndVisitAtAndStatus(eq(userId), any(LocalDateTime.class),
+			eq(ReservationStatus.CONFIRMED))).willReturn(false);
+		given(dailySlotCapacityRepository.findBySlotIdAndDate(slotId, date)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> reservationService.create(email, new ReservationRequestDto(slotId, date, 2, "")))
+			.isInstanceOf(ReservationException.class)
+			.satisfies(ex -> {
+				ReservationException re = (ReservationException)ex;
+				assertThat(re.getErrorCode()).isEqualTo(ErrorCode.RESERVATION_SLOT_NOT_OPENED);
+			});
+	}
+
+	@Test
+	@DisplayName("실패 - 좌석 부족")
+	void create_fail_capacityNotEnough() {
+		// given
+		String email = "customer01@test.com";
+		Long userId = 1L;
+		Long slotId = 10L;
+		Long restaurantId = 100L;
+		LocalDate date = LocalDate.of(2026, 1, 26);
+		LocalTime slotTime = LocalTime.of(19, 0);
+
+		DailySlotCapacity capacity = DailySlotCapacity.builder()
+			.capacityId(777L)
+			.slotId(slotId)
+			.date(date)
+			.remainingCount(1)
+			.maxCount(10)
+			.version(0L)
+			.build();
+
+		given(userRepository.findByEmail(email)).willReturn(Optional.of(createTestUser(userId, email)));
+		given(restaurantSlotRepository.findById(slotId)).willReturn(
+			Optional.of(createTestSlot(slotId, restaurantId, slotTime)));
+		given(reservationRepository.existsByUserIdAndVisitAtAndStatus(eq(userId), any(LocalDateTime.class),
+			eq(ReservationStatus.CONFIRMED))).willReturn(false);
+		given(dailySlotCapacityRepository.findBySlotIdAndDate(slotId, date)).willReturn(Optional.of(capacity));
+
+		// when & then
+		assertThatThrownBy(() -> reservationService.create(email, new ReservationRequestDto(slotId, date, 2, "")))
+			.isInstanceOf(ReservationException.class)
+			.satisfies(ex -> {
+				ReservationException re = (ReservationException)ex;
+				assertThat(re.getErrorCode()).isEqualTo(ErrorCode.RESERVATION_CAPACITY_NOT_ENOUGH);
+			});
+	}
+
+	private User createTestUser(Long userId, String email) {
+		return User.builder()
+			.userId(userId)
+			.email(email)
+			.name("유저")
+			.phone("010-0000-0000")
+			.password("encrypted-password")
+			.userRole(UserRole.CUSTOMER)
+			.build();
+	}
+
+	private RestaurantSlot createTestSlot(Long slotId, Long restaurantId, LocalTime time) {
+		return RestaurantSlot.builder()
+			.slotId(slotId)
+			.restaurantId(restaurantId)
+			.time(time)
+			.maxCapacity(10)
+			.build();
+	}
+}

--- a/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceTest.java
@@ -70,14 +70,13 @@ class ReservationServiceTest {
 			.slotId(slotId)
 			.date(date)
 			.remainingCount(10)
-			.maxCount(10)
 			.version(0L)
 			.build();
 
 		ReservationRequestDto req = new ReservationRequestDto(slotId, date, partySize, "note");
 
-		given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
-		given(restaurantSlotRepository.findById(slotId)).willReturn(Optional.of(slot));
+		given(userRepository.fetchByEmail(email)).willReturn(user);
+		given(restaurantSlotRepository.fetchById(slotId)).willReturn(slot);
 		given(reservationRepository.existsByUserIdAndVisitAtAndStatus(userId, LocalDateTime.of(date, slotTime),
 			ReservationStatus.CONFIRMED)).willReturn(false);
 		given(dailySlotCapacityRepository.findBySlotIdAndDate(slotId, date)).willReturn(Optional.of(capacity));
@@ -195,7 +194,6 @@ class ReservationServiceTest {
 			.slotId(slotId)
 			.date(date)
 			.remainingCount(1)
-			.maxCount(10)
 			.version(0L)
 			.build();
 

--- a/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceTest.java
@@ -105,9 +105,7 @@ class ReservationServiceTest {
 		assertThat(saved.getPartySize()).isEqualTo(partySize);
 		assertThat(saved.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
 
-		ArgumentCaptor<DailySlotCapacity> capacityCaptor = ArgumentCaptor.forClass(DailySlotCapacity.class);
-		verify(dailySlotCapacityRepository, times(1)).update(capacityCaptor.capture());
-		assertThat(capacityCaptor.getValue().getRemainingCount()).isEqualTo(8);
+		verify(dailySlotCapacityRepository, times(1)).updateRemainingCount(eq(777L), eq(8));
 	}
 
 	@Test
@@ -185,7 +183,7 @@ class ReservationServiceTest {
 				.isEqualTo(ErrorCode.RESERVATION_SLOT_NOT_OPENED));
 
 		verify(reservationRepository, never()).save(any());
-		verify(dailySlotCapacityRepository, never()).update(any());
+		verify(dailySlotCapacityRepository, never()).updateRemainingCount(anyLong(), anyInt());
 	}
 
 	@Test
@@ -224,7 +222,7 @@ class ReservationServiceTest {
 				.isEqualTo(ErrorCode.RESERVATION_CAPACITY_NOT_ENOUGH));
 
 		verify(reservationRepository, never()).save(any());
-		verify(dailySlotCapacityRepository, never()).update(any());
+		verify(dailySlotCapacityRepository, never()).updateRemainingCount(anyLong(), anyInt());
 	}
 
 	@Test

--- a/src/test/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationControllerIntegrationTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationControllerIntegrationTest.java
@@ -1,0 +1,208 @@
+package com.reservation.tablereservationservice.presentation.reservation.controller;
+
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacity;
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacityRepository;
+import com.reservation.tablereservationservice.domain.reservation.ReservationRepository;
+import com.reservation.tablereservationservice.domain.restaurant.CategoryCode;
+import com.reservation.tablereservationservice.domain.restaurant.RegionCode;
+import com.reservation.tablereservationservice.domain.restaurant.Restaurant;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantRepository;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlot;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlotRepository;
+import com.reservation.tablereservationservice.domain.user.User;
+import com.reservation.tablereservationservice.domain.user.UserRepository;
+import com.reservation.tablereservationservice.domain.user.UserRole;
+import com.reservation.tablereservationservice.global.jwt.JwtProvider;
+import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationRequestDto;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class ReservationControllerIntegrationTest {
+
+	@LocalServerPort
+	private int port;
+
+	@Autowired
+	private JwtProvider jwtProvider;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private ReservationRepository reservationRepository;
+
+	@Autowired
+	private RestaurantRepository restaurantRepository;
+
+	@Autowired
+	private RestaurantSlotRepository restaurantSlotRepository;
+
+	@Autowired
+	private DailySlotCapacityRepository dailySlotCapacityRepository;
+
+	private Long slotId;
+	private LocalDate date;
+	private LocalTime slotTime;
+
+	private String customerAccessToken;
+	private String ownerAccessToken;
+
+	@BeforeEach
+	void setUp() {
+		reservationRepository.deleteAll();
+		dailySlotCapacityRepository.deleteAll();
+		restaurantSlotRepository.deleteAll();
+		restaurantRepository.deleteAll();
+		userRepository.deleteAll();
+
+		RestAssured.port = port;
+		this.date = LocalDate.of(2026, 1, 26);
+		this.slotTime = LocalTime.of(19, 0);
+
+		User owner = userRepository.save(User.builder()
+			.email("owner@test.com")
+			.name("사장님")
+			.phone("010-0000-0001")
+			.password("encrypted-password")
+			.userRole(UserRole.OWNER)
+			.build());
+
+		User customer = userRepository.save(User.builder()
+			.email("customer@test.com")
+			.name("테스터")
+			.phone("010-0000-0002")
+			.password("encrypted-password")
+			.userRole(UserRole.CUSTOMER)
+			.build());
+
+		// 토큰은 직접 발급
+		this.ownerAccessToken = jwtProvider.createAccessToken(owner.getEmail(), UserRole.OWNER);
+		this.customerAccessToken = jwtProvider.createAccessToken(customer.getEmail(), UserRole.CUSTOMER);
+
+		Restaurant restaurant = restaurantRepository.save(Restaurant.builder()
+			.name("강남 한상")
+			.regionCode(RegionCode.RG01)
+			.categoryCode(CategoryCode.CT01)
+			.address("서울 강남구 테헤란로 1")
+			.ownerId(owner.getUserId())
+			.build());
+
+		RestaurantSlot slot = restaurantSlotRepository.save(RestaurantSlot.builder()
+			.restaurantId(restaurant.getRestaurantId())
+			.time(slotTime)
+			.maxCapacity(10)
+			.build());
+
+		this.slotId = slot.getSlotId();
+
+		dailySlotCapacityRepository.save(DailySlotCapacity.builder()
+			.slotId(slotId)
+			.date(date)
+			.remainingCount(10)
+			.maxCount(10)
+			.version(0L)
+			.build());
+	}
+
+	@Test
+	@DisplayName("예약 요청 성공 - CUSTOMER 토큰이면 200 + 응답 바디 반환")
+	void create_Success_WhenCustomerToken() {
+		ReservationRequestDto request = new ReservationRequestDto(slotId, date, 2, "note");
+
+		given()
+			.contentType(ContentType.JSON)
+			.header("Authorization", "Bearer " + customerAccessToken)
+			.body(request)
+		.when()
+			.post("/api/reservations")
+		.then()
+			  .statusCode(200)
+			  .body("code", equalTo(200))
+			  .body("message", equalTo("예약 요청 성공"))
+			  .body("data.reservationId", notNullValue())
+			  .body("data.partySize", equalTo(2))
+			  .body("data.status", equalTo("CONFIRMED"))
+			  .body("data.visitAt", equalTo("2026-01-26T19:00:00"));
+
+	}
+
+	@Test
+	@DisplayName("예약 요청 실패 - OWNER 토큰이면 403")
+	void create_Fail_WhenOwnerToken() {
+		ReservationRequestDto request = new ReservationRequestDto(
+			slotId,
+			date,
+			2,
+			"note"
+		);
+
+		given()
+			.contentType(ContentType.JSON)
+			.header("Authorization", "Bearer " + ownerAccessToken)
+			.body(request)
+		.when()
+			.post("/api/reservations")
+		.then()
+			.statusCode(403);
+	}
+
+	@Test
+	@DisplayName("예약 요청 실패 - 토큰 없이 요청하면 401")
+	void create_Fail_WithoutToken() {
+		ReservationRequestDto request = new ReservationRequestDto(
+			slotId,
+			date,
+			2,
+			"note"
+		);
+
+		given()
+			.contentType(ContentType.JSON)
+			.body(request)
+		.when()
+			.post("/api/reservations")
+		.then()
+			.statusCode(401);
+	}
+
+	@Test
+	@DisplayName("예약 요청 실패 - DTO 검증 실패면 400 + 상세 에러 반환")
+	void create_Fail_InvalidRequestDto() {
+		ReservationRequestDto request = new ReservationRequestDto(
+			null,
+			null,
+			0,
+			"note"
+		);
+
+		given()
+			.contentType(ContentType.JSON)
+			.header("Authorization", "Bearer " + customerAccessToken)
+			.body(request)
+		.when()
+			.post("/api/reservations")
+		.then()
+			.statusCode(400)
+			.body("code", equalTo(400))
+			.body("data.slotId", notNullValue())
+			.body("data.date", notNullValue())
+			.body("data.partySize", notNullValue());
+	}
+}

--- a/src/test/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationControllerIntegrationTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationControllerIntegrationTest.java
@@ -116,7 +116,6 @@ class ReservationControllerIntegrationTest {
 			.slotId(slotId)
 			.date(date)
 			.remainingCount(10)
-			.maxCount(10)
 			.version(0L)
 			.build());
 	}

--- a/src/test/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationControllerTest.java
@@ -1,0 +1,258 @@
+package com.reservation.tablereservationservice.presentation.reservation.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.reservation.tablereservationservice.application.reservation.service.ReservationService;
+import com.reservation.tablereservationservice.domain.reservation.Reservation;
+import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
+import com.reservation.tablereservationservice.global.config.SecurityConfig;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.GlobalExceptionHandler;
+import com.reservation.tablereservationservice.global.exception.ReservationException;
+import com.reservation.tablereservationservice.presentation.common.ApiResponse;
+import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationRequestDto;
+import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationResponseDto;
+
+@WebMvcTest(ReservationController.class)
+@Import({GlobalExceptionHandler.class, ReservationControllerTest.TestSecurityConfig.class})
+@AutoConfigureMockMvc
+class ReservationControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private ReservationService reservationService;
+
+	@MockitoBean
+	private Authentication authentication;
+
+	@Test
+	@DisplayName("예약 요청 성공 - CUSTOMER 권한이면 200 및 응답 바디 반환")
+	void create_success_whenCustomerRole() throws Exception {
+		// given
+		String email = "customer01@test.com";
+		LocalDate date = LocalDate.of(2026, 1, 26);
+
+		ReservationRequestDto requestDto = new ReservationRequestDto(
+			10L,
+			date,
+			2,
+			"note"
+		);
+
+		Reservation reservation = Reservation.builder()
+			.reservationId(999L)
+			.userId(1L)
+			.slotId(10L)
+			.visitAt(LocalDateTime.of(2026, 1, 26, 19, 0))
+			.partySize(2)
+			.note("note")
+			.status(ReservationStatus.CONFIRMED)
+			.build();
+
+		given(reservationService.create(eq(email), any(ReservationRequestDto.class)))
+			.willReturn(reservation);
+
+		Authentication auth = new UsernamePasswordAuthenticationToken(
+			email,
+			null,
+			java.util.List.of(new SimpleGrantedAuthority("ROLE_CUSTOMER"))
+		);
+
+		// when
+		MvcResult mvcResult = mockMvc.perform(post("/api/reservations")
+				.with(authentication(auth))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(requestDto)))
+			.andReturn();
+
+		// then
+		ApiResponse<ReservationResponseDto> response = readResponse(
+			mvcResult,
+			new TypeReference<ApiResponse<ReservationResponseDto>>() {
+			}
+		);
+
+		assertThat(response.getCode()).isEqualTo(200);
+		assertThat(response.getMessage()).isEqualTo("예약 요청 성공");
+
+		ReservationResponseDto data = response.getData();
+		assertThat(data).isNotNull();
+		assertThat(data.getReservationId()).isEqualTo(999L);
+		assertThat(data.getPartySize()).isEqualTo(2);
+
+		verify(reservationService, times(1)).create(eq(email), any(ReservationRequestDto.class));
+	}
+
+	@Test
+	@DisplayName("예약 요청 실패 - 요청 DTO 검증 실패 시 400 + 상세 에러 메시지 반환")
+	void create_InvalidRequestDto_ReturnsBadRequest() throws Exception {
+		// given
+		String email = "customer01@test.com";
+
+		ReservationRequestDto requestDto = new ReservationRequestDto(
+			null,
+			null,
+			0,
+			"note"
+		);
+
+		Authentication auth = new UsernamePasswordAuthenticationToken(
+			email,
+			null,
+			java.util.List.of(new SimpleGrantedAuthority("ROLE_CUSTOMER"))
+		);
+
+		// when
+		MvcResult mvcResult = mockMvc.perform(post("/api/reservations")
+				.with(authentication(auth))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(requestDto)))
+			.andReturn();
+
+		// then
+		ApiResponse<Map<String, String>> response = readResponse(
+			mvcResult,
+			new TypeReference<ApiResponse<Map<String, String>>>() {
+			}
+		);
+
+		assertThat(response.getCode()).isEqualTo(400);
+		assertThat(response.getMessage()).isEqualTo(ErrorCode.INVALID_INPUT_VALUE.getMessage());
+
+		Map<String, String> errors = response.getData();
+		assertThat(errors).isNotNull();
+		assertThat(errors).containsKeys("slotId", "date", "partySize");
+		assertThat(errors.get("slotId")).isEqualTo("slotId는 필수입니다.");
+		assertThat(errors.get("date")).isEqualTo("예약 날짜는 필수입니다.");
+		assertThat(errors.get("partySize")).isEqualTo("예약 인원은 1명 이상이어야 합니다.");
+
+		verify(reservationService, times(0)).create(anyString(), any());
+	}
+
+	@Test
+	@DisplayName("예약 요청 실패 - CUSTOMER 권한이 아니면 403")
+	void create_Fail_NotCustomerRole_ReturnsForbidden() throws Exception {
+		// given
+		String email = "owner@test.com";
+		ReservationRequestDto requestDto = new ReservationRequestDto(
+			10L,
+			LocalDate.of(2026, 1, 26),
+			2,
+			"note"
+		);
+
+		Authentication auth = new UsernamePasswordAuthenticationToken(
+			email,
+			null,
+			java.util.List.of(new SimpleGrantedAuthority("ROLE_OWNER"))
+		);
+
+		// when
+		MvcResult mvcResult = mockMvc.perform(post("/api/reservations")
+				.with(authentication(auth))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(requestDto)))
+			.andReturn();
+
+		// then
+		assertThat(mvcResult.getResponse().getStatus()).isEqualTo(403);
+		verify(reservationService, times(0)).create(anyString(), any());
+	}
+
+	@Test
+	@DisplayName("예약 요청 실패 - 중복 예약 예외 발생 시 409 응답")
+	void create_Fail_DuplicatedTime_ReturnsConflict() throws Exception {
+		// given
+		String email = "customer01@test.com";
+		ReservationRequestDto requestDto = new ReservationRequestDto(
+			10L,
+			LocalDate.of(2026, 1, 26),
+			2,
+			""
+		);
+
+		given(reservationService.create(eq(email), any(ReservationRequestDto.class)))
+			.willThrow(new ReservationException(ErrorCode.RESERVATION_DUPLICATED_TIME));
+
+		Authentication auth = new UsernamePasswordAuthenticationToken(
+			email,
+			null,
+			java.util.List.of(new SimpleGrantedAuthority("ROLE_CUSTOMER"))
+		);
+		// when
+		MvcResult mvcResult = mockMvc.perform(post("/api/reservations")
+				.with(authentication(auth))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(requestDto)))
+			.andReturn();
+
+		// then
+		ApiResponse<Void> response = readResponse(
+			mvcResult,
+			new TypeReference<ApiResponse<Void>>() {
+			}
+		);
+
+		assertThat(response.getCode()).isEqualTo(409);
+		assertThat(response.getMessage()).isEqualTo(ErrorCode.RESERVATION_DUPLICATED_TIME.getMessage());
+		assertThat(response.getData()).isNull();
+
+		verify(reservationService, times(1)).create(eq(email), any(ReservationRequestDto.class));
+	}
+
+	private <T> ApiResponse<T> readResponse(
+		MvcResult mvcResult,
+		TypeReference<ApiResponse<T>> typeRef
+	) throws Exception {
+		String body = mvcResult.getResponse().getContentAsString();
+		return objectMapper.readValue(body, typeRef);
+	}
+
+	@TestConfiguration
+	@EnableMethodSecurity(prePostEnabled = true)
+	static class TestSecurityConfig {
+
+	    @Bean
+		SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+	        // WebMvcTest에서 403/401/CSRF 흐름만 확인하려면 최소 설정으로 둠
+	        return http
+	            .csrf(csrf -> csrf.disable())
+	            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+	            .build();
+	    }
+	}
+}

--- a/src/test/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationControllerTest.java
@@ -34,7 +34,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.reservation.tablereservationservice.application.reservation.service.ReservationService;
 import com.reservation.tablereservationservice.domain.reservation.Reservation;
 import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
-import com.reservation.tablereservationservice.global.config.SecurityConfig;
 import com.reservation.tablereservationservice.global.exception.ErrorCode;
 import com.reservation.tablereservationservice.global.exception.GlobalExceptionHandler;
 import com.reservation.tablereservationservice.global.exception.ReservationException;
@@ -243,16 +242,16 @@ class ReservationControllerTest {
 	}
 
 	@TestConfiguration
-	@EnableMethodSecurity(prePostEnabled = true)
+	@EnableMethodSecurity
 	static class TestSecurityConfig {
 
-	    @Bean
+		@Bean
 		SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
-	        // WebMvcTest에서 403/401/CSRF 흐름만 확인하려면 최소 설정으로 둠
-	        return http
-	            .csrf(csrf -> csrf.disable())
-	            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
-	            .build();
-	    }
+			// WebMvcTest에서 403/401/CSRF 흐름만 확인하려면 최소 설정으로 둠
+			return http
+				.csrf(csrf -> csrf.disable())
+				.authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+				.build();
+		}
 	}
 }


### PR DESCRIPTION
## 개요
- 예약 요청 기능 구현 1차

## 메인 리뷰어 지정
- 메인 리뷰어 : @blue000927 

## 리뷰 시 참고 사항
- **예약 상태 정책 변경**
  - 기존에는 점주가 예약 요청을 승인해야 예약이 확정되는 구조였으나, 예약 요청 시점에 조건이 만족하면 즉시 `CONFIRMED` 상태로 확정되도록 정책을 변경했습니다.
  - 변경 사유: 승인 대기 상태(`PENDING`)가 길어질 경우, 사용자 입장에서는 예약 성공 여부를 즉시 알기 어렵고 UX가 저하된다고 판단했습니다.
- 동일 사용자가 동일 방문 시각에 중복 예약하지 못하도록 DB 유니크 제약 조건을 추가했습니다.
- `DailySlotCapacity`에 version 기반 낙관적 락을 적용했습니다. (재시도는 우선 제외했습니다.)

## TODO
- 예약 취소 시 좌석 수량 복구 로직 추가

## References
- <!--사용된 레퍼런스에 대한 링크를 남겨주세요.-->

## 체크리스트
- [x] PR 제목을 명령형으로 작성했습니다.
- [x] PR을 연관되는 github issue에 연결했습니다.
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트 코드가 필요없는 이유가 있습니다.

## 관련 이슈
- closed #5
