### PR TITLE
예약 취소 기능 구현

### DIFF
--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacity.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacity.java
@@ -35,4 +35,8 @@ public class DailySlotCapacity {
 		return true;
 	}
 
+	public void increase(int partySize) {
+		this.remainingCount += partySize;
+	}
+
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/Reservation.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/Reservation.java
@@ -28,4 +28,8 @@ public class Reservation {
 		this.status = status;
 	}
 
+	public void cancel() {
+		this.status = ReservationStatus.CANCELED;
+	}
+
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/Reservation.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/Reservation.java
@@ -28,6 +28,23 @@ public class Reservation {
 		this.status = status;
 	}
 
+	public boolean isOwner(Long userId) {
+		return this.userId != null && this.userId.equals(userId);
+	}
+
+	public boolean isAlreadyCanceled() {
+		return this.status == ReservationStatus.CANCELED;
+	}
+
+	/**
+	 * 취소 가능 기한(방문 24시간 전) 내에 있는지 확인
+	 * @param now 현재 시점
+	 */
+	public boolean canCancelAt(LocalDateTime now) {
+		LocalDateTime cancelDeadline = this.visitAt.minusHours(24);
+		return now.isBefore(cancelDeadline);
+	}
+
 	public void cancel() {
 		this.status = ReservationStatus.CANCELED;
 	}

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/ReservationRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/ReservationRepository.java
@@ -13,5 +13,7 @@ public interface ReservationRepository {
 
 	Reservation fetchById(Long reservationId);
 
+	void updateStatus(Reservation reservation);
+
 	void deleteAll();
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/ReservationRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/ReservationRepository.java
@@ -1,12 +1,17 @@
 package com.reservation.tablereservationservice.domain.reservation;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public interface ReservationRepository {
 
 	Reservation save(Reservation reservation);
 
 	boolean existsByUserIdAndVisitAtAndStatus(Long userId, LocalDateTime visitAt, ReservationStatus reservationStatus);
+
+	Optional<Reservation> findById(Long reservationId);
+
+	Reservation fetchById(Long reservationId);
 
 	void deleteAll();
 }

--- a/src/main/java/com/reservation/tablereservationservice/global/exception/ErrorCode.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/exception/ErrorCode.java
@@ -15,6 +15,8 @@ public enum ErrorCode {
 	INVALID_PARTY_SIZE("예약 인원 수가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
 	RESERVATION_SLOT_NOT_OPENED("해당 날짜의 예약이 오픈되지 않았습니다.", HttpStatus.BAD_REQUEST),
 	INVALID_RESERVATION_REQUEST("유효하지 않은 예약 요청입니다.", HttpStatus.BAD_REQUEST),
+	RESERVATION_ALREADY_CANCELED("이미 취소된 예약입니다.", HttpStatus.BAD_REQUEST),
+	RESERVATION_CANCEL_DEADLINE_PASSED("예약 취소는 방문 24시간 전까지 가능합니다.", HttpStatus.BAD_REQUEST),
 
 	// 401 Unauthorized
 	UNAUTHORIZED("인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
@@ -24,6 +26,7 @@ public enum ErrorCode {
 
 	// 403 Forbidden
 	ACCESS_DENIED("접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+	RESERVATION_FORBIDDEN("본인의 예약만 취소할 수 있습니다.", HttpStatus.FORBIDDEN),
 
 	// 404 Not Found
 	RESOURCE_NOT_FOUND("%s를(을) 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
@@ -41,4 +44,4 @@ public enum ErrorCode {
 
 	private final String message;
 	private final HttpStatus status;
-}
+	}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/ReservationEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/ReservationEntity.java
@@ -65,4 +65,8 @@ public class ReservationEntity extends BaseTimeEntity {
 		this.note = note;
 		this.status = status;
 	}
+
+	public void updateStatus(ReservationStatus status) {
+	    this.status = status;
+	}
 }

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaReservationRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaReservationRepository.java
@@ -1,12 +1,15 @@
 package com.reservation.tablereservationservice.infrastructure.reservation.repository;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
 import com.reservation.tablereservationservice.domain.reservation.Reservation;
 import com.reservation.tablereservationservice.domain.reservation.ReservationRepository;
 import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.ReservationException;
 import com.reservation.tablereservationservice.infrastructure.reservation.entity.ReservationEntity;
 import com.reservation.tablereservationservice.infrastructure.reservation.mapper.ReservationMapper;
 
@@ -30,6 +33,18 @@ public class JpaReservationRepository implements ReservationRepository {
 	public boolean existsByUserIdAndVisitAtAndStatus(Long userId, LocalDateTime visitAt,
 		ReservationStatus reservationStatus) {
 		return reservationEntityRepository.existsByUserIdAndVisitAtAndStatus(userId, visitAt, reservationStatus);
+	}
+
+	@Override
+	public Optional<Reservation> findById(Long reservationId) {
+		return reservationEntityRepository.findById(reservationId)
+			.map(ReservationMapper.INSTANCE::toDomain);
+	}
+
+	@Override
+	public Reservation fetchById(Long reservationId) {
+		return findById(reservationId)
+			.orElseThrow(() -> new ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "Reservation"));
 	}
 
 	@Override

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaReservationRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaReservationRepository.java
@@ -48,6 +48,15 @@ public class JpaReservationRepository implements ReservationRepository {
 	}
 
 	@Override
+	public void updateStatus(Reservation reservation) {
+		ReservationEntity entity = reservationEntityRepository.findById(reservation.getReservationId())
+			.orElseThrow(() -> new ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "Reservation"));
+
+		entity.updateStatus(reservation.getStatus());
+		// save() 호출 없음 -> 변경 감지 UPDATE
+	}
+
+	@Override
 	public void deleteAll() {
 		reservationEntityRepository.deleteAll();
 	}

--- a/src/main/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationController.java
+++ b/src/main/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationController.java
@@ -2,6 +2,7 @@ package com.reservation.tablereservationservice.presentation.reservation.control
 
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,6 +33,16 @@ public class ReservationController {
 		ReservationResponseDto responseDto = ReservationResponseDto.from(reservation);
 
 		return ApiResponse.success("예약 요청 성공", responseDto);
+	}
+
+	@PreAuthorize("hasRole('CUSTOMER')")
+	@PostMapping("/{reservationId}/cancel")
+	public ApiResponse<ReservationResponseDto> cancel(@PathVariable Long reservationId, Authentication authentication) {
+		String email = (String)authentication.getPrincipal();
+		Reservation reservation = reservationService.cancel(email, reservationId);
+		ReservationResponseDto responseDto = ReservationResponseDto.from(reservation);
+
+		return ApiResponse.success("예약 취소 성공", responseDto);
 	}
 
 }

--- a/src/main/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationController.java
+++ b/src/main/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationController.java
@@ -3,10 +3,8 @@ package com.reservation.tablereservationservice.presentation.reservation.control
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -83,11 +81,10 @@ public class ReservationController {
 
 	}
 
-	@PreAuthorize("hasRole('CUSTOMER')")
+	@CustomerOnly
 	@PostMapping("/{reservationId}/cancel")
-	public ApiResponse<ReservationResponseDto> cancel(@PathVariable Long reservationId, Authentication authentication) {
-		String email = (String)authentication.getPrincipal();
-		Reservation reservation = reservationService.cancel(email, reservationId);
+	public ApiResponse<ReservationResponseDto> cancel(@PathVariable Long reservationId, @LoginUser CurrentUser user) {
+		Reservation reservation = reservationService.cancel(user.email(), reservationId);
 		ReservationResponseDto responseDto = ReservationResponseDto.from(reservation);
 
 		return ApiResponse.success("예약 취소 성공", responseDto);

--- a/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceIntegrationTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceIntegrationTest.java
@@ -43,9 +43,8 @@ import com.reservation.tablereservationservice.presentation.reservation.dto.Rese
 @Transactional
 class ReservationServiceIntegrationTest {
 
-	private static final LocalDate TEST_DATE = LocalDate.of(2026, 1, 26);
-	private static final LocalTime TEST_TIME = LocalTime.of(19, 0);
-	private static final LocalDateTime TEST_VISIT_AT = LocalDateTime.of(TEST_DATE, TEST_TIME);
+	private static final LocalDate BASE_DATE = LocalDate.of(2030, 1, 1);
+	private static final LocalTime BASE_TIME = LocalTime.of(19, 0);
 	private static final Pageable PAGEABLE = PageRequest.of(0, 10);
 
 	@Autowired
@@ -68,19 +67,15 @@ class ReservationServiceIntegrationTest {
 
 	private User customer;
 	private User owner;
+	private Restaurant restaurant;
 	private RestaurantSlot restaurantSlot;
 
 	@BeforeEach
 	void setUp() {
-		customer = userRepository.save(
-			UserFixture.customer().build()
-		);
+		customer = userRepository.save(UserFixture.customer().build());
+		owner = userRepository.save(UserFixture.owner().build());
 
-		owner = userRepository.save(
-			UserFixture.owner().build()
-		);
-
-		Restaurant restaurant = restaurantRepository.save(
+		restaurant = restaurantRepository.save(
 			RestaurantFixture.restaurant()
 				.ownerId(owner.getUserId())
 				.build()
@@ -89,7 +84,7 @@ class ReservationServiceIntegrationTest {
 		restaurantSlot = restaurantSlotRepository.save(
 			RestaurantSlotFixture.slot()
 				.restaurantId(restaurant.getRestaurantId())
-				.time(TEST_TIME)
+				.time(BASE_TIME)
 				.maxCapacity(10)
 				.build()
 		);
@@ -99,16 +94,12 @@ class ReservationServiceIntegrationTest {
 	@DisplayName("예약 생성 성공 - CONFIRMED 저장 + capacity 차감")
 	void create_success_confirmed_and_decreaseCapacity() {
 		// given
+		LocalDate date = BASE_DATE;
 		int partySize = 2;
-		dailySlotCapacityRepository.save(
-			DailySlotCapacityFixture.capacity()
-				.slotId(restaurantSlot.getSlotId())
-				.date(TEST_DATE)
-				.remainingCount(10)
-				.build()
-		);
 
-		ReservationRequestDto req = new ReservationRequestDto(restaurantSlot.getSlotId(), TEST_DATE, partySize, "note");
+		saveCapacity(restaurantSlot.getSlotId(), date, 10);
+
+		ReservationRequestDto req = createReservationRequest(restaurantSlot.getSlotId(), date, partySize, "note");
 
 		// when
 		Reservation saved = reservationService.create(customer.getEmail(), req);
@@ -117,122 +108,106 @@ class ReservationServiceIntegrationTest {
 		assertThat(saved.getReservationId()).isNotNull();
 		assertThat(saved.getUserId()).isEqualTo(customer.getUserId());
 		assertThat(saved.getSlotId()).isEqualTo(restaurantSlot.getSlotId());
-		assertThat(saved.getVisitAt()).isEqualTo(TEST_VISIT_AT);
+		assertThat(saved.getVisitAt()).isEqualTo(date.atTime(restaurantSlot.getTime()));
 		assertThat(saved.getPartySize()).isEqualTo(partySize);
 		assertThat(saved.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
 
-		DailySlotCapacity after = dailySlotCapacityRepository.findBySlotIdAndDate(restaurantSlot.getSlotId(), TEST_DATE)
+		DailySlotCapacity after = dailySlotCapacityRepository.findBySlotIdAndDate(restaurantSlot.getSlotId(), date)
 			.orElseThrow(() -> new IllegalStateException("DailySlotCapacity not found"));
 		assertThat(after.getRemainingCount()).isEqualTo(8);
 
-		// 저장된 예약이 실제로 CONFIRMED로 존재하는지
 		assertThat(reservationRepository.existsByUserIdAndVisitAtAndStatus(
 			customer.getUserId(),
-			TEST_VISIT_AT,
+			date.atTime(restaurantSlot.getTime()),
 			ReservationStatus.CONFIRMED
 		)).isTrue();
 	}
 
 	@Test
-	@DisplayName("중복 예약 실패")
+	@DisplayName("중복 예약 실패 - 같은 유저/같은 방문시각")
 	void create_fail_duplicatedTime_preCheck() {
 		// given
-		dailySlotCapacityRepository.save(
-			DailySlotCapacityFixture.capacity()
-				.slotId(restaurantSlot.getSlotId())
-				.date(TEST_DATE)
-				.remainingCount(10)
-				.build()
-		);
+		LocalDate date = BASE_DATE;
+		saveCapacity(restaurantSlot.getSlotId(), date, 10);
 
-		reservationService.create(
-			customer.getEmail(),
-			new ReservationRequestDto(restaurantSlot.getSlotId(), TEST_DATE, 2, "")
-		);
+		ReservationRequestDto firstReq = createReservationRequest(restaurantSlot.getSlotId(), date, 2, "");
+		ReservationRequestDto secondReq = createReservationRequest(restaurantSlot.getSlotId(), date, 2, "");
+
+		reservationService.create(customer.getEmail(), firstReq);
 
 		// when & then
-		// 동일한 조건으로 다시 예약 (동일 유저, 같은 날짜)
-		assertThatThrownBy(() -> reservationService.create(
-			customer.getEmail(),
-			new ReservationRequestDto(restaurantSlot.getSlotId(), TEST_DATE, 2, "")
-		))
+		assertThatThrownBy(() -> reservationService.create(customer.getEmail(), secondReq))
 			.isInstanceOf(ReservationException.class)
-			.satisfies(ex -> {
-				ReservationException re = (ReservationException)ex;
-				assertThat(re.getErrorCode()).isEqualTo(ErrorCode.RESERVATION_DUPLICATED_TIME);
-			});
+			.satisfies(ex -> assertThat(((ReservationException)ex).getErrorCode())
+				.isEqualTo(ErrorCode.RESERVATION_DUPLICATED_TIME));
 
-		DailySlotCapacity after = dailySlotCapacityRepository.findBySlotIdAndDate(restaurantSlot.getSlotId(), TEST_DATE)
+		DailySlotCapacity after = dailySlotCapacityRepository.findBySlotIdAndDate(restaurantSlot.getSlotId(), date)
 			.orElseThrow(() -> new IllegalStateException("DailySlotCapacity not found"));
-		assertThat(after.getRemainingCount()).isEqualTo(8); // 첫 번째 예약에서만 2명이 차감된다.
+		assertThat(after.getRemainingCount()).isEqualTo(8); // 첫 번째 예약만 차감
 	}
 
 	@Test
-	@DisplayName("좌석 부족 실패")
+	@DisplayName("좌석 부족 실패 - capacity 부족이면 예약 미생성 + capacity 유지")
 	void create_fail_capacityNotEnough() {
 		// given
-		dailySlotCapacityRepository.save(
-			DailySlotCapacityFixture.capacity()
-				.slotId(restaurantSlot.getSlotId())
-				.date(TEST_DATE)
-				.remainingCount(1) // remainingCount를 1로 만들어서 준비
-				.build()
-		);
+		LocalDate date = BASE_DATE;
+		int partySize = 5;
 
-		int partySize = 5; // 실제 요청은 5
+		saveCapacity(restaurantSlot.getSlotId(), date, 1); // remainingCount를 1로 만들어서 준비
+
+		ReservationRequestDto req = createReservationRequest(restaurantSlot.getSlotId(), date, partySize, "");
 
 		// when & then
-		assertThatThrownBy(
-			() -> reservationService.create(
-				customer.getEmail(),
-				new ReservationRequestDto(restaurantSlot.getSlotId(), TEST_DATE, partySize, "")
-			))
+		assertThatThrownBy(() -> reservationService.create(customer.getEmail(), req))
 			.isInstanceOf(ReservationException.class)
-			.satisfies(ex -> {
-				ReservationException re = (ReservationException)ex;
-				assertThat(re.getErrorCode()).isEqualTo(ErrorCode.RESERVATION_CAPACITY_NOT_ENOUGH);
-			});
+			.satisfies(ex -> assertThat(((ReservationException)ex).getErrorCode())
+				.isEqualTo(ErrorCode.RESERVATION_CAPACITY_NOT_ENOUGH));
 
-		// 실패면 예약 저장이 없어야 하고, capacity는 그대로(1)여야 함
-		DailySlotCapacity after = dailySlotCapacityRepository.findBySlotIdAndDate(restaurantSlot.getSlotId(), TEST_DATE)
+		DailySlotCapacity after = dailySlotCapacityRepository.findBySlotIdAndDate(restaurantSlot.getSlotId(), date)
 			.orElseThrow(() -> new IllegalStateException("DailySlotCapacity not found"));
 		assertThat(after.getRemainingCount()).isEqualTo(1);
 	}
 
 	@Test
-	@DisplayName("슬롯 미오픈 실패 - capacity row 없음 (RESERVATION_SLOT_NOT_OPENED)")
+	@DisplayName("슬롯 미오픈 실패 - capacity row 없음")
 	void create_fail_slotNotOpened() {
 		// given
 		// capacity를 저장하지 않는다 = 미오픈 상태
-		ReservationRequestDto req = new ReservationRequestDto(restaurantSlot.getSlotId(), TEST_DATE, 2, "");
+		ReservationRequestDto req = createReservationRequest(restaurantSlot.getSlotId(), BASE_DATE, 2, "");
 
 		// when & then
 		assertThatThrownBy(() -> reservationService.create(customer.getEmail(), req))
 			.isInstanceOf(ReservationException.class)
-			.satisfies(ex -> {
-				ReservationException re = (ReservationException)ex;
-				assertThat(re.getErrorCode()).isEqualTo(ErrorCode.RESERVATION_SLOT_NOT_OPENED);
-			});
+			.satisfies(ex -> assertThat(((ReservationException)ex).getErrorCode())
+				.isEqualTo(ErrorCode.RESERVATION_SLOT_NOT_OPENED));
 	}
 
 	@Test
-	@DisplayName("사용자 예약 목록 조회 성공 - 1건")
-	void findMyReservations_success() {
+	@DisplayName("사용자 예약 목록 조회 성공 - status/기간 조건에 따라 필터링된다")
+	void findMyReservations_success_filteringByStatusAndPeriod() {
 		// given
-		dailySlotCapacityRepository.save(
-			DailySlotCapacityFixture.capacity()
-				.slotId(restaurantSlot.getSlotId())
-				.date(TEST_DATE)
-				.remainingCount(10)
-				.build()
-		);
+		LocalDate inRangeDate = BASE_DATE;
+		LocalDate outRangeDate = BASE_DATE.minusDays(10);
 
-		reservationService.create(
-			customer.getEmail(),
-			new ReservationRequestDto(restaurantSlot.getSlotId(), TEST_DATE, 2, "note")
-		);
+		saveCapacity(restaurantSlot.getSlotId(), inRangeDate, 10);
+		saveCapacity(restaurantSlot.getSlotId(), outRangeDate, 10);
 
-		ReservationSearchDto searchDto = createSearchDto();
+		ReservationRequestDto inRangeReq =
+			createReservationRequest(restaurantSlot.getSlotId(), inRangeDate, 2, "note");
+		ReservationRequestDto outRangeReq =
+			createReservationRequest(restaurantSlot.getSlotId(), outRangeDate, 2, "note");
+
+		Reservation inRange = reservationService.create(customer.getEmail(), inRangeReq);
+		Reservation outRange = reservationService.create(customer.getEmail(), outRangeReq);
+
+		// outRange를 취소해서 status 필터도 같이 검증
+		reservationService.cancel(customer.getEmail(), outRange.getReservationId());
+
+		ReservationSearchDto searchDto = createSearchDto(
+			BASE_DATE.minusDays(3),
+			BASE_DATE.plusDays(1),
+			ReservationStatus.CONFIRMED
+		);
 
 		// when
 		PageResponseDto<ReservationListResponseDto> result =
@@ -240,26 +215,96 @@ class ReservationServiceIntegrationTest {
 
 		// then
 		assertThat(result.getContent()).hasSize(1);
+		assertThat(result.getContent().getFirst().getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+		assertThat(result.getContent().getFirst().getVisitAt()).isEqualTo(inRange.getVisitAt());
 	}
 
 	@Test
-	@DisplayName("점주 예약 목록 조회 성공 - 1건")
-	void findOwnerReservations_success() {
+	@DisplayName("사용자 예약 목록 조회 - status=CONFIRMED면 취소된 예약은 제외된다")
+	void findMyReservations_success_onlyConfirmed_whenStatusConfirmed() {
 		// given
-		dailySlotCapacityRepository.save(
-			DailySlotCapacityFixture.capacity()
-				.slotId(restaurantSlot.getSlotId())
-				.date(TEST_DATE)
-				.remainingCount(10)
-				.build()
+		LocalDate date = BASE_DATE;
+
+		saveCapacity(restaurantSlot.getSlotId(), date, 10);
+		saveCapacity(restaurantSlot.getSlotId(), date.plusDays(1), 10);
+
+		ReservationRequestDto confirmedReq =
+			createReservationRequest(restaurantSlot.getSlotId(), date, 2, "note-confirmed");
+		ReservationRequestDto canceledReq =
+			createReservationRequest(restaurantSlot.getSlotId(), date.plusDays(1), 2, "note-canceled");
+
+		Reservation confirmed = reservationService.create(customer.getEmail(), confirmedReq);
+		Reservation willBeCanceled = reservationService.create(customer.getEmail(), canceledReq);
+		reservationService.cancel(customer.getEmail(), willBeCanceled.getReservationId());
+
+		ReservationSearchDto searchDto = createSearchDto(
+			BASE_DATE.minusDays(1),
+			BASE_DATE.plusDays(2),
+			ReservationStatus.CONFIRMED
 		);
 
-		reservationService.create(
-			customer.getEmail(),
-			new ReservationRequestDto(restaurantSlot.getSlotId(), TEST_DATE, 2, "note")
+		// when
+		PageResponseDto<ReservationListResponseDto> result =
+			reservationService.findMyReservations(customer.getEmail(), searchDto);
+
+		// then
+		assertThat(result.getContent()).hasSize(1);
+		assertThat(result.getContent().getFirst().getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+		assertThat(result.getContent().getFirst().getVisitAt()).isEqualTo(confirmed.getVisitAt());
+	}
+
+	@Test
+	@DisplayName("사용자 예약 목록 조회 - status=null이면 확정/취소 모두 조회된다")
+	void findMyReservations_success_allStatuses_whenStatusNull() {
+		// given
+		LocalDate date = BASE_DATE;
+
+		saveCapacity(restaurantSlot.getSlotId(), date, 10);
+		saveCapacity(restaurantSlot.getSlotId(), date.plusDays(1), 10);
+
+		ReservationRequestDto confirmedReq =
+			createReservationRequest(restaurantSlot.getSlotId(), date, 2, "confirmed");
+		ReservationRequestDto canceledReq =
+			createReservationRequest(restaurantSlot.getSlotId(), date.plusDays(1), 2, "canceled");
+
+		reservationService.create(customer.getEmail(), confirmedReq);
+
+		Reservation canceledTarget = reservationService.create(customer.getEmail(), canceledReq);
+		reservationService.cancel(customer.getEmail(), canceledTarget.getReservationId());
+
+		ReservationSearchDto searchDto = createSearchDto(
+			BASE_DATE.minusDays(1),
+			BASE_DATE.plusDays(2),
+			null
 		);
 
-		ReservationSearchDto searchDto = createSearchDto();
+		// when
+		PageResponseDto<ReservationListResponseDto> result =
+			reservationService.findMyReservations(customer.getEmail(), searchDto);
+
+		// then
+		assertThat(result.getContent()).hasSize(2);
+		assertThat(result.getContent())
+			.extracting(ReservationListResponseDto::getStatus)
+			.containsExactlyInAnyOrder(ReservationStatus.CONFIRMED, ReservationStatus.CANCELED);
+	}
+
+	@Test
+	@DisplayName("점주 예약 목록 조회 성공 - owner의 가게 예약 1건 조회된다")
+	void findOwnerReservations_success_singleReservation() {
+		// given
+		LocalDate date = BASE_DATE;
+
+		saveCapacity(restaurantSlot.getSlotId(), date, 10);
+		ReservationRequestDto req = createReservationRequest(restaurantSlot.getSlotId(), date, 2, "note");
+
+		reservationService.create(customer.getEmail(), req);
+
+		ReservationSearchDto searchDto = createSearchDto(
+			BASE_DATE.minusDays(1),
+			BASE_DATE.plusDays(1),
+			ReservationStatus.CONFIRMED
+		);
 
 		// when
 		PageResponseDto<ReservationListResponseDto> result =
@@ -267,22 +312,24 @@ class ReservationServiceIntegrationTest {
 
 		// then
 		assertThat(result.getContent()).hasSize(1);
+		assertThat(result.getContent().getFirst().getRestaurantName()).isEqualTo(restaurant.getName());
+		assertThat(result.getContent().getFirst().getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
 	}
 
 	@Test
 	@DisplayName("예약 취소 성공 - 상태 CANCELED 저장 + capacity 복구")
 	void cancel_success_canceled_and_restoreCapacity() {
 		// given
+		Long slotId = restaurantSlot.getSlotId();
+		String email = customer.getEmail();
 		int partySize = 2;
 
-		LocalDate visitDate = LocalDate.now().plusDays(2);
+		LocalDate visitDate = BASE_DATE.plusDays(3);
+
 		saveCapacity(slotId, visitDate, 10);
 
-		ReservationRequestDto req = new ReservationRequestDto(slotId, visitDate, partySize, "note");
+		ReservationRequestDto req = createReservationRequest(slotId, visitDate, partySize, "note");
 		Reservation created = reservationService.create(email, req);
-
-		Long reservationId = created.getReservationId();
-		assertThat(reservationId).isNotNull();
 
 		// 생성 시점 capacity가 10 -> 8로 감소했는지 확인
 		DailySlotCapacity afterCreate = dailySlotCapacityRepository.findBySlotIdAndDate(slotId, visitDate)
@@ -290,107 +337,117 @@ class ReservationServiceIntegrationTest {
 		assertThat(afterCreate.getRemainingCount()).isEqualTo(8);
 
 		// when
-		Reservation canceled = reservationService.cancel(email, reservationId);
+		Reservation canceled = reservationService.cancel(email, created.getReservationId());
 
 		// then
-		assertThat(canceled.getReservationId()).isEqualTo(reservationId);
 		assertThat(canceled.getStatus()).isEqualTo(ReservationStatus.CANCELED);
 
 		// DB에 실제 반영됐는지 재조회로 확인
-		Reservation stored = reservationRepository.findById(reservationId)
+		Reservation stored = reservationRepository.findById(created.getReservationId())
 			.orElseThrow(() -> new IllegalStateException("Reservation not found"));
 		assertThat(stored.getStatus()).isEqualTo(ReservationStatus.CANCELED);
 
-		// capacity 복구(8 -> 10)
 		DailySlotCapacity afterCancel = dailySlotCapacityRepository.findBySlotIdAndDate(slotId, visitDate)
 			.orElseThrow(() -> new IllegalStateException("DailySlotCapacity not found"));
-		assertThat(afterCancel.getRemainingCount()).isEqualTo(10);
+		assertThat(afterCancel.getRemainingCount()).isEqualTo(10);    // capacity 복구(8 -> 10)
 	}
 
 	@Test
-	@DisplayName("예약 취소 실패 - 다른 유저 예약 취소 시도 (RESERVATION_FORBIDDEN)")
+	@DisplayName("예약 취소 실패 - 다른 유저 예약 취소 시도")
 	void cancel_fail_forbidden() {
 		// given
+		Long slotId = restaurantSlot.getSlotId();
 		int partySize = 2;
-		LocalDate visitDate = LocalDate.now().plusDays(2);
+		LocalDate visitDate = BASE_DATE.plusDays(3);
+
 		saveCapacity(slotId, visitDate, 10);
 
-		ReservationRequestDto req = new ReservationRequestDto(slotId, visitDate, partySize, "note");
-		Reservation created = reservationService.create(email, req);
+		ReservationRequestDto req = createReservationRequest(slotId, visitDate, partySize, "note");
+		Reservation created = reservationService.create(customer.getEmail(), req);
 
-		Long reservationId = created.getReservationId();
-
-		// 다른 유저 생성
-		String otherEmail = "other@test.com";
-		userRepository.save(User.builder()
-			.email(otherEmail)
-			.name("other")
-			.phone("010-0000-9999")
-			.password("encrypted-password")
-			.userRole(UserRole.CUSTOMER)
-			.build());
+		User other = userRepository.save(
+			UserFixture.customer()
+				.userId(3L)
+				.email("other@test.com")
+				.phone("010-0000-9999")
+				.build()
+		);
 
 		// when & then
-		assertThatThrownBy(() -> reservationService.cancel(otherEmail, reservationId))
+		assertThatThrownBy(() -> reservationService.cancel(other.getEmail(), created.getReservationId()))
 			.isInstanceOf(ReservationException.class)
 			.satisfies(ex -> assertThat(((ReservationException)ex).getErrorCode())
 				.isEqualTo(ErrorCode.RESERVATION_FORBIDDEN));
 	}
 
 	@Test
-	@DisplayName("예약 취소 실패 - 이미 취소된 예약 (RESERVATION_ALREADY_CANCELED)")
+	@DisplayName("예약 취소 실패 - 이미 취소된 예약")
 	void cancel_fail_alreadyCanceled() {
 		// given
+		LocalDate visitDate = BASE_DATE.plusDays(3);
+		Long slotId = restaurantSlot.getSlotId();
 		int partySize = 2;
-		LocalDate visitDate = LocalDate.now().plusDays(2);
+
 		saveCapacity(slotId, visitDate, 10);
 
-		ReservationRequestDto req = new ReservationRequestDto(slotId, visitDate, partySize, "note");
-		Reservation created = reservationService.create(email, req);
-
-		Long reservationId = created.getReservationId();
+		ReservationRequestDto req = createReservationRequest(slotId, visitDate, partySize, "note");
+		Reservation created = reservationService.create(customer.getEmail(), req);
 
 		// 한 번 취소 성공
-		reservationService.cancel(email, reservationId);
+		reservationService.cancel(customer.getEmail(), created.getReservationId());
 
 		// when & then (두 번째 취소)
-		assertThatThrownBy(() -> reservationService.cancel(email, reservationId))
+		assertThatThrownBy(() -> reservationService.cancel(customer.getEmail(), created.getReservationId()))
 			.isInstanceOf(ReservationException.class)
 			.satisfies(ex -> assertThat(((ReservationException)ex).getErrorCode())
 				.isEqualTo(ErrorCode.RESERVATION_ALREADY_CANCELED));
 	}
 
 	@Test
-	@DisplayName("예약 취소 실패 - 취소 가능 기한(24시간) 지남 (RESERVATION_CANCEL_DEADLINE_PASSED)")
+	@DisplayName("예약 취소 실패 - 취소 가능 기한(24시간) 지남")
 	void cancel_fail_deadlinePassed() {
 		// given
+		Long slotId = restaurantSlot.getSlotId();
 		int partySize = 2;
 
-		// visitAt이 현재 + 10시간이면(24시간 이내) => 취소 불가
-		LocalDateTime base = LocalDateTime.of(date, slotTime); // setUp의 date/slotTime 활용
-		LocalDateTime visitAt = base.plusHours(1);
-		LocalDate visitDate = visitAt.toLocalDate();
+		// visitAt이 현재로부터 24시간 이내면 취소 불가
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime visitAt = now.plusHours(23);
+		LocalDate date = visitAt.toLocalDate();
 
-		saveCapacity(slotId, visitDate, 8);
+		saveCapacity(slotId, date, 8);
 
-		ReservationRequestDto req = new ReservationRequestDto(slotId, visitDate, partySize, "note");
-		Reservation created = reservationService.create(email, req);
+		ReservationRequestDto req = createReservationRequest(slotId, date, partySize, "note");
+		Reservation created = reservationService.create(customer.getEmail(), req);
 		Long reservationId = created.getReservationId();
 
 		// when & then
-		assertThatThrownBy(() -> reservationService.cancel(email, reservationId))
+		assertThatThrownBy(() -> reservationService.cancel(customer.getEmail(), reservationId))
 			.isInstanceOf(ReservationException.class)
 			.satisfies(ex -> assertThat(((ReservationException)ex).getErrorCode())
 				.isEqualTo(ErrorCode.RESERVATION_CANCEL_DEADLINE_PASSED));
 	}
 
-	private ReservationSearchDto createSearchDto() {
+	private void saveCapacity(Long slotId, LocalDate date, int remainingCount) {
+		dailySlotCapacityRepository.save(
+			DailySlotCapacityFixture.capacity()
+				.slotId(slotId)
+				.date(date)
+				.remainingCount(remainingCount)
+				.build()
+		);
+	}
+
+	private ReservationSearchDto createSearchDto(LocalDate fromDate, LocalDate toDate, ReservationStatus status) {
 		ReservationSearchDto searchDto = new ReservationSearchDto();
-		searchDto.setFromDate(TEST_DATE);
-		searchDto.setToDate(TEST_DATE);
-		searchDto.setStatus(ReservationStatus.CONFIRMED);
+		searchDto.setFromDate(fromDate);
+		searchDto.setToDate(toDate);
+		searchDto.setStatus(status);
 		searchDto.setPageable(PAGEABLE);
 		return searchDto;
 	}
 
+	private ReservationRequestDto createReservationRequest(Long slotId, LocalDate date, int partySize, String note) {
+		return new ReservationRequestDto(slotId, date, partySize, note);
+	}
 }

--- a/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceIntegrationTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceIntegrationTest.java
@@ -206,6 +206,121 @@ class ReservationServiceIntegrationTest {
 			});
 	}
 
+	@Test
+	@DisplayName("예약 취소 성공 - 상태 CANCELED 저장 + capacity 복구")
+	void cancel_success_canceled_and_restoreCapacity() {
+		// given
+		int partySize = 2;
+
+		LocalDate visitDate = LocalDate.now().plusDays(2);
+		saveCapacity(slotId, visitDate, 10);
+
+		ReservationRequestDto req = new ReservationRequestDto(slotId, visitDate, partySize, "note");
+		Reservation created = reservationService.create(email, req);
+
+		Long reservationId = created.getReservationId();
+		assertThat(reservationId).isNotNull();
+
+		// 생성 시점 capacity가 10 -> 8로 감소했는지 확인
+		DailySlotCapacity afterCreate = dailySlotCapacityRepository.findBySlotIdAndDate(slotId, visitDate)
+			.orElseThrow(() -> new IllegalStateException("DailySlotCapacity not found"));
+		assertThat(afterCreate.getRemainingCount()).isEqualTo(8);
+
+		// when
+		Reservation canceled = reservationService.cancel(email, reservationId);
+
+		// then
+		assertThat(canceled.getReservationId()).isEqualTo(reservationId);
+		assertThat(canceled.getStatus()).isEqualTo(ReservationStatus.CANCELED);
+
+		// DB에 실제 반영됐는지 재조회로 확인
+		Reservation stored = reservationRepository.findById(reservationId)
+			.orElseThrow(() -> new IllegalStateException("Reservation not found"));
+		assertThat(stored.getStatus()).isEqualTo(ReservationStatus.CANCELED);
+
+		// capacity 복구(8 -> 10)
+		DailySlotCapacity afterCancel = dailySlotCapacityRepository.findBySlotIdAndDate(slotId, visitDate)
+			.orElseThrow(() -> new IllegalStateException("DailySlotCapacity not found"));
+		assertThat(afterCancel.getRemainingCount()).isEqualTo(10);
+	}
+
+	@Test
+	@DisplayName("예약 취소 실패 - 다른 유저 예약 취소 시도 (RESERVATION_FORBIDDEN)")
+	void cancel_fail_forbidden() {
+		// given
+		int partySize = 2;
+		LocalDate visitDate = LocalDate.now().plusDays(2);
+		saveCapacity(slotId, visitDate, 10);
+
+		ReservationRequestDto req = new ReservationRequestDto(slotId, visitDate, partySize, "note");
+		Reservation created = reservationService.create(email, req);
+
+		Long reservationId = created.getReservationId();
+
+		// 다른 유저 생성
+		String otherEmail = "other@test.com";
+		userRepository.save(User.builder()
+			.email(otherEmail)
+			.name("other")
+			.phone("010-0000-9999")
+			.password("encrypted-password")
+			.userRole(UserRole.CUSTOMER)
+			.build());
+
+		// when & then
+		assertThatThrownBy(() -> reservationService.cancel(otherEmail, reservationId))
+			.isInstanceOf(ReservationException.class)
+			.satisfies(ex -> assertThat(((ReservationException)ex).getErrorCode())
+				.isEqualTo(ErrorCode.RESERVATION_FORBIDDEN));
+	}
+
+	@Test
+	@DisplayName("예약 취소 실패 - 이미 취소된 예약 (RESERVATION_ALREADY_CANCELED)")
+	void cancel_fail_alreadyCanceled() {
+		// given
+		int partySize = 2;
+		LocalDate visitDate = LocalDate.now().plusDays(2);
+		saveCapacity(slotId, visitDate, 10);
+
+		ReservationRequestDto req = new ReservationRequestDto(slotId, visitDate, partySize, "note");
+		Reservation created = reservationService.create(email, req);
+
+		Long reservationId = created.getReservationId();
+
+		// 한 번 취소 성공
+		reservationService.cancel(email, reservationId);
+
+		// when & then (두 번째 취소)
+		assertThatThrownBy(() -> reservationService.cancel(email, reservationId))
+			.isInstanceOf(ReservationException.class)
+			.satisfies(ex -> assertThat(((ReservationException)ex).getErrorCode())
+				.isEqualTo(ErrorCode.RESERVATION_ALREADY_CANCELED));
+	}
+
+	@Test
+	@DisplayName("예약 취소 실패 - 취소 가능 기한(24시간) 지남 (RESERVATION_CANCEL_DEADLINE_PASSED)")
+	void cancel_fail_deadlinePassed() {
+		// given
+		int partySize = 2;
+
+		// visitAt이 현재 + 10시간이면(24시간 이내) => 취소 불가
+		LocalDateTime base = LocalDateTime.of(date, slotTime); // setUp의 date/slotTime 활용
+		LocalDateTime visitAt = base.plusHours(1);
+		LocalDate visitDate = visitAt.toLocalDate();
+
+		saveCapacity(slotId, visitDate, 8);
+
+		ReservationRequestDto req = new ReservationRequestDto(slotId, visitDate, partySize, "note");
+		Reservation created = reservationService.create(email, req);
+		Long reservationId = created.getReservationId();
+
+		// when & then
+		assertThatThrownBy(() -> reservationService.cancel(email, reservationId))
+			.isInstanceOf(ReservationException.class)
+			.satisfies(ex -> assertThat(((ReservationException)ex).getErrorCode())
+				.isEqualTo(ErrorCode.RESERVATION_CANCEL_DEADLINE_PASSED));
+	}
+
 	private void saveCapacity(Long slotId, LocalDate date, int remainingCount) {
 		DailySlotCapacity capacity = DailySlotCapacity.builder()
 			.slotId(slotId)

--- a/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceTest.java
@@ -35,6 +35,8 @@ import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlotR
 import com.reservation.tablereservationservice.domain.user.User;
 import com.reservation.tablereservationservice.domain.user.UserRepository;
 import com.reservation.tablereservationservice.fixture.DailySlotCapacityFixture;
+import com.reservation.tablereservationservice.fixture.ReservationFixture;
+import com.reservation.tablereservationservice.fixture.RestaurantFixture;
 import com.reservation.tablereservationservice.fixture.RestaurantSlotFixture;
 import com.reservation.tablereservationservice.fixture.UserFixture;
 import com.reservation.tablereservationservice.global.exception.ErrorCode;
@@ -48,9 +50,8 @@ import com.reservation.tablereservationservice.presentation.reservation.dto.Rese
 @ExtendWith(MockitoExtension.class)
 class ReservationServiceTest {
 
-	private static final LocalDate TEST_DATE = LocalDate.of(2026, 1, 26);
-	private static final LocalTime TEST_TIME = LocalTime.of(19, 0);
-	private static final LocalDateTime TEST_VISIT_AT = LocalDateTime.of(TEST_DATE, TEST_TIME);
+	private static final LocalDate BASE_DATE = LocalDate.of(2030, 1, 1);
+	private static final LocalTime BASE_TIME = LocalTime.of(19, 0);
 	private static final Pageable PAGEABLE = PageRequest.of(0, 10);
 
 	@Mock
@@ -77,10 +78,18 @@ class ReservationServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		customer = UserFixture.customer().build();
-		owner = UserFixture.owner().build();
+		customer = UserFixture
+			.customer()
+			.userId(1L)
+			.build();
+
+		owner = UserFixture.owner()
+			.userId(2L)
+			.build();
+
 		restaurantSlot = RestaurantSlotFixture.slot()
-			.time(TEST_TIME)
+			.slotId(100L)
+			.time(BASE_TIME)
 			.build();
 	}
 
@@ -88,48 +97,44 @@ class ReservationServiceTest {
 	@DisplayName("예약 요청 성공 - CONFIRMED 저장 + capacity 차감")
 	void create_success() {
 		// given
+		LocalDate date = BASE_DATE;
+		LocalDateTime visitAt = LocalDateTime.of(date, restaurantSlot.getTime());
+		int partySize = 2;
+
 		DailySlotCapacity capacity = DailySlotCapacityFixture.capacity()
 			.slotId(restaurantSlot.getSlotId())
-			.date(TEST_DATE)
+			.date(date)
 			.remainingCount(10)
 			.build();
 
-		int partySize = 2;
-
-		ReservationRequestDto req = new ReservationRequestDto(restaurantSlot.getSlotId(), TEST_DATE, partySize, "note");
+		ReservationRequestDto req = createReservationRequest(restaurantSlot.getSlotId(), date, partySize, "note");
 
 		given(userRepository.fetchByEmail(customer.getEmail())).willReturn(customer);
 		given(restaurantSlotRepository.fetchById(restaurantSlot.getSlotId())).willReturn(restaurantSlot);
 		given(reservationRepository.existsByUserIdAndVisitAtAndStatus(
-			customer.getUserId(),
-			TEST_VISIT_AT,
-			ReservationStatus.CONFIRMED
+			customer.getUserId(), visitAt, ReservationStatus.CONFIRMED
 		)).willReturn(false);
 
-		given(dailySlotCapacityRepository.findBySlotIdAndDate(
-			restaurantSlot.getSlotId(),
-			TEST_DATE
-		)).willReturn(Optional.of(capacity));
+		given(dailySlotCapacityRepository.findBySlotIdAndDate(restaurantSlot.getSlotId(), date))
+			.willReturn(Optional.of(capacity));
 
 		given(reservationRepository.save(any(Reservation.class))).willAnswer(inv -> inv.getArgument(0));
 
 		// when
 		Reservation saved = reservationService.create(customer.getEmail(), req);
 
-		// then
+		// then (반환값은 핵심만 확인)
 		assertThat(saved.getUserId()).isEqualTo(customer.getUserId());
-		assertThat(saved.getSlotId()).isEqualTo(restaurantSlot.getSlotId());
-		assertThat(saved.getVisitAt()).isEqualTo(TEST_VISIT_AT);
-		assertThat(saved.getPartySize()).isEqualTo(partySize);
 		assertThat(saved.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
 
 		// then - save argument 검증
 		ArgumentCaptor<Reservation> reservationCaptor = ArgumentCaptor.forClass(Reservation.class);
 		verify(reservationRepository).save(reservationCaptor.capture());
+
 		Reservation captured = reservationCaptor.getValue();
 		assertThat(captured.getUserId()).isEqualTo(customer.getUserId());
 		assertThat(captured.getSlotId()).isEqualTo(restaurantSlot.getSlotId());
-		assertThat(captured.getVisitAt()).isEqualTo(TEST_VISIT_AT);
+		assertThat(captured.getVisitAt()).isEqualTo(visitAt);
 		assertThat(captured.getPartySize()).isEqualTo(partySize);
 		assertThat(captured.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
 
@@ -143,10 +148,10 @@ class ReservationServiceTest {
 	@DisplayName("예약 요청 실패 - 유저 없음")
 	void create_fail_userNotFound() {
 		// given
+		ReservationRequestDto req = createReservationRequest(restaurantSlot.getSlotId(), BASE_DATE, 2, "");
+
 		given(userRepository.fetchByEmail(customer.getEmail()))
 			.willThrow(new UserException(ErrorCode.RESOURCE_NOT_FOUND, "User"));
-
-		ReservationRequestDto req = new ReservationRequestDto(restaurantSlot.getSlotId(), TEST_DATE, 2, "");
 
 		// when & then
 		assertThatThrownBy(() -> reservationService.create(customer.getEmail(), req))
@@ -159,14 +164,17 @@ class ReservationServiceTest {
 	@DisplayName("예약 요청 실패 - 중복 예약 예외 발생")
 	void create_fail_duplicatedTime_preCheck() {
 		// given
+		LocalDate date = BASE_DATE;
+		LocalDateTime visitAt = LocalDateTime.of(date, restaurantSlot.getTime());
+
+		ReservationRequestDto req = createReservationRequest(restaurantSlot.getSlotId(), date, 2, "");
+
 		given(userRepository.fetchByEmail(customer.getEmail())).willReturn(customer);
 		given(restaurantSlotRepository.fetchById(restaurantSlot.getSlotId())).willReturn(restaurantSlot);
 
 		given(reservationRepository.existsByUserIdAndVisitAtAndStatus(
-			customer.getUserId(), TEST_VISIT_AT, ReservationStatus.CONFIRMED
+			customer.getUserId(), visitAt, ReservationStatus.CONFIRMED
 		)).willReturn(true);
-
-		ReservationRequestDto req = new ReservationRequestDto(restaurantSlot.getSlotId(), TEST_DATE, 2, "");
 
 		// when & then
 		assertThatThrownBy(() -> reservationService.create(customer.getEmail(), req))
@@ -182,17 +190,20 @@ class ReservationServiceTest {
 	@DisplayName("예약 요청 실패 - capacity row 없음(해당 날짜 슬롯 미오픈)")
 	void create_fail_slotNotOpened() {
 		// given
+		LocalDate date = BASE_DATE;
+		LocalDateTime visitAt = LocalDateTime.of(date, restaurantSlot.getTime());
+
+		ReservationRequestDto req = createReservationRequest(restaurantSlot.getSlotId(), date, 2, "");
+
 		given(userRepository.fetchByEmail(customer.getEmail())).willReturn(customer);
 		given(restaurantSlotRepository.fetchById(restaurantSlot.getSlotId())).willReturn(restaurantSlot);
 
 		given(reservationRepository.existsByUserIdAndVisitAtAndStatus(
-			customer.getUserId(), TEST_VISIT_AT, ReservationStatus.CONFIRMED
+			customer.getUserId(), visitAt, ReservationStatus.CONFIRMED
 		)).willReturn(false);
 
-		given(dailySlotCapacityRepository.findBySlotIdAndDate(restaurantSlot.getSlotId(), TEST_DATE
-		)).willReturn(Optional.empty());
-
-		ReservationRequestDto req = new ReservationRequestDto(restaurantSlot.getSlotId(), TEST_DATE, 2, "");
+		given(dailySlotCapacityRepository.findBySlotIdAndDate(restaurantSlot.getSlotId(), date))
+			.willReturn(Optional.empty());
 
 		// when & then
 		assertThatThrownBy(() -> reservationService.create(customer.getEmail(), req))
@@ -208,25 +219,26 @@ class ReservationServiceTest {
 	@DisplayName("예약 요청 실패 - 좌석 부족")
 	void create_fail_capacityNotEnough() {
 		// given
+		LocalDate date = BASE_DATE;
+		LocalDateTime visitAt = LocalDateTime.of(date, restaurantSlot.getTime());
+
 		DailySlotCapacity capacity = DailySlotCapacityFixture.capacity()
 			.slotId(restaurantSlot.getSlotId())
-			.date(TEST_DATE)
+			.date(date)
 			.remainingCount(1)
 			.build();
+
+		ReservationRequestDto req = createReservationRequest(restaurantSlot.getSlotId(), date, 2, "");
 
 		given(userRepository.fetchByEmail(customer.getEmail())).willReturn(customer);
 		given(restaurantSlotRepository.fetchById(restaurantSlot.getSlotId())).willReturn(restaurantSlot);
 
 		given(reservationRepository.existsByUserIdAndVisitAtAndStatus(
-			customer.getUserId(),
-			TEST_VISIT_AT,
-			ReservationStatus.CONFIRMED
+			customer.getUserId(), visitAt, ReservationStatus.CONFIRMED
 		)).willReturn(false);
 
-		given(dailySlotCapacityRepository.findBySlotIdAndDate(restaurantSlot.getSlotId(), TEST_DATE))
+		given(dailySlotCapacityRepository.findBySlotIdAndDate(restaurantSlot.getSlotId(), date))
 			.willReturn(Optional.of(capacity));
-
-		ReservationRequestDto req = new ReservationRequestDto(restaurantSlot.getSlotId(), TEST_DATE, 2, "");
 
 		// when & then
 		assertThatThrownBy(() -> reservationService.create(customer.getEmail(), req))
@@ -239,37 +251,42 @@ class ReservationServiceTest {
 	}
 
 	@Test
-	@DisplayName("사용자 예약 목록 조회 성공")
+	@DisplayName("사용자 예약 목록 조회 성공 - 검색 조건이 repository 파라미터로 전달된다.")
 	void findMyReservations_success() {
 		// given
-		ReservationSearchDto searchDto = createSearchDto();
+		LocalDate fromDate = BASE_DATE.minusDays(1);
+		LocalDate toDate = BASE_DATE.plusDays(7);
+		ReservationStatus status = ReservationStatus.CONFIRMED;
 
-		Long slotId = 10L;
-		Long restaurantId = 100L;
-		ReservationListFixture fixture = reservationListFixture(customer.getUserId(), slotId, restaurantId);
+		ReservationSearchDto searchDto = createSearchDto(fromDate, toDate, status);
+
+		Reservation reservation = ReservationFixture.confirmed()
+			.userId(customer.getUserId())
+			.slotId(restaurantSlot.getSlotId())
+			.visitAt(LocalDateTime.of(BASE_DATE, restaurantSlot.getTime()))
+			.build();
+
+		Page<Reservation> page = new PageImpl<>(List.of(reservation), PAGEABLE, 1);
+
+		Restaurant restaurant = RestaurantFixture.restaurant()
+			.restaurantId(restaurantSlot.getRestaurantId())
+			.name("강남 한상")
+			.build();
 
 		given(userRepository.fetchByEmail(customer.getEmail())).willReturn(customer);
-
-		Page<Reservation> confirmedOnlyPage =
-			new PageImpl<>(
-				fixture.page().getContent().stream()
-					.filter(r -> r.getStatus() == ReservationStatus.CONFIRMED)
-					.toList(), PAGEABLE, 1
-			);
-
 		given(reservationRepository.findMyReservations(
 			eq(customer.getUserId()),
-			eq(ReservationStatus.CONFIRMED),
-			any(),
-			any(),
-			any()
-		)).willReturn(confirmedOnlyPage);
+			eq(status),
+			eq(fromDate.atStartOfDay()),
+			eq(toDate.atTime(LocalTime.MAX)),
+			eq(PAGEABLE)
+		)).willReturn(page);
 
 		given(restaurantSlotRepository.findAllById(anyList()))
-			.willReturn(List.of(fixture.slot()));
+			.willReturn(List.of(restaurantSlot));
 
 		given(restaurantRepository.findAllById(anyList()))
-			.willReturn(List.of(fixture.restaurant()));
+			.willReturn(List.of(restaurant));
 
 		// when
 		PageResponseDto<ReservationListResponseDto> result =
@@ -278,40 +295,57 @@ class ReservationServiceTest {
 		// then
 		assertThat(result.getContent()).hasSize(1);
 		assertThat(result.getContent().getFirst().getRestaurantName()).isEqualTo("강남 한상");
-		assertThat(result.getContent().getFirst().getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+		assertThat(result.getContent().getFirst().getStatus()).isEqualTo(status);
 	}
 
 	@Test
-	@DisplayName("점주 예약 목록 조회 성공")
+	@DisplayName("점주 예약 목록 조회 성공 - 검색 조건이 repository 파라미터로 전달된다.")
 	void findOwnerReservations_success() {
 		// given
-		ReservationSearchDto searchDto = createSearchDto();
+		LocalDate fromDate = BASE_DATE.minusDays(1);
+		LocalDate toDate = BASE_DATE.plusDays(7);
+		ReservationStatus status = ReservationStatus.CONFIRMED;
 
-		Long ownerRestaurantId = 2L;
-		Long slotId = 10L;
+		ReservationSearchDto searchDto = createSearchDto(fromDate, toDate, status);
 
-		ReservationListFixture fixture = reservationListFixture(customer.getUserId(), slotId, ownerRestaurantId);
+		Restaurant ownerRestaurant = RestaurantFixture.restaurant()
+			.restaurantId(200L)
+			.ownerId(owner.getUserId())
+			.build();
+
+		RestaurantSlot ownerSlot = RestaurantSlotFixture.slot()
+			.slotId(300L)
+			.restaurantId(ownerRestaurant.getRestaurantId())
+			.time(BASE_TIME)
+			.build();
+
+		Reservation reservation = ReservationFixture.confirmed()
+			.userId(customer.getUserId())
+			.slotId(ownerSlot.getSlotId())
+			.visitAt(LocalDateTime.of(BASE_DATE, ownerSlot.getTime()))
+			.build();
+
+		Page<Reservation> page = new PageImpl<>(List.of(reservation), PAGEABLE, 1);
 
 		given(userRepository.fetchByEmail(owner.getEmail())).willReturn(owner);
 
 		given(restaurantRepository.findAllByOwnerId(owner.getUserId()))
-			.willReturn(List.of(fixture.restaurant()));
+			.willReturn(List.of(ownerRestaurant));
 
 		given(reservationRepository.findOwnerReservations(
-			eq(List.of(ownerRestaurantId)),
-			eq(ReservationStatus.CONFIRMED),
-			any(),
-			any(),
-			any()
-		)).willReturn(fixture.page());
+			eq(List.of(ownerRestaurant.getRestaurantId())),
+			eq(status),
+			eq(fromDate.atStartOfDay()),
+			eq(toDate.atTime(LocalTime.MAX)),
+			eq(PAGEABLE)
+		)).willReturn(page);
 
 		given(restaurantSlotRepository.findAllById(anyList()))
-			.willReturn(List.of(fixture.slot()));
+			.willReturn(List.of(ownerSlot));
 
 		given(restaurantRepository.findAllById(anyList()))
-			.willReturn(List.of(fixture.restaurant()));
+			.willReturn(List.of(ownerRestaurant));
 
-		// owner 조회는 예약자 정보가 여러 명이므로 userRepository.findAllById 호출됨
 		given(userRepository.findAllById(anyList()))
 			.willReturn(List.of(customer));
 
@@ -321,51 +355,46 @@ class ReservationServiceTest {
 
 		// then
 		assertThat(result.getContent()).hasSize(1);
-		assertThat(result.getContent().getFirst().getRestaurantName()).isEqualTo("강남 한상");
-		assertThat(result.getContent().getFirst().getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+		assertThat(result.getContent().getFirst().getRestaurantName()).isEqualTo(ownerRestaurant.getName());
+		assertThat(result.getContent().getFirst().getStatus()).isEqualTo(status);
+
+		verify(restaurantSlotRepository).findAllById(argThat(ids -> ids.contains(300L)));
+		verify(restaurantRepository).findAllById(argThat(ids -> ids.contains(200L)));
 	}
 
 	@Test
 	@DisplayName("예약 취소 성공 - CANCELED 저장 + capacity 복구")
 	void cancel_success() {
 		// given
-		String email = "customer01@test.com";
-		Long userId = 1L;
 		Long reservationId = 999L;
-		Long slotId = 10L;
-
-		LocalDateTime visitAt = LocalDateTime.now().plusDays(2);
-		LocalDate date = visitAt.toLocalDate();
-
 		int partySize = 2;
 
-		User user = createTestUser(userId, email);
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime visitAt = now.plusDays(2);
+		LocalDate date = visitAt.toLocalDate();
 
-		Reservation reservation = Reservation.builder()
+		Reservation reservation = ReservationFixture.confirmed()
 			.reservationId(reservationId)
-			.userId(userId)
-			.slotId(slotId)
+			.userId(customer.getUserId())
+			.slotId(restaurantSlot.getSlotId())
 			.visitAt(visitAt)
 			.partySize(partySize)
-			.note("note")
-			.status(ReservationStatus.CONFIRMED)
 			.build();
 
-		DailySlotCapacity capacity = DailySlotCapacity.builder()
+		DailySlotCapacity capacity = DailySlotCapacityFixture.capacity()
 			.capacityId(777L)
-			.slotId(slotId)
+			.slotId(reservation.getSlotId())
 			.date(date)
-			.remainingCount(8) // 현재 남은 수량
-			.version(0L)
+			.remainingCount(8)
 			.build();
 
-		given(userRepository.fetchByEmail(email)).willReturn(user);
+		given(userRepository.fetchByEmail(customer.getEmail())).willReturn(customer);
 		given(reservationRepository.fetchById(reservationId)).willReturn(reservation);
-		given(dailySlotCapacityRepository.findBySlotIdAndDate(slotId, date)).willReturn(Optional.of(capacity));
-		given(reservationRepository.save(any(Reservation.class))).willAnswer(inv -> inv.getArgument(0));
+		given(dailySlotCapacityRepository.findBySlotIdAndDate(reservation.getSlotId(), date))
+			.willReturn(Optional.of(capacity));
 
 		// when
-		Reservation canceled = reservationService.cancel(email, reservationId);
+		Reservation canceled = reservationService.cancel(customer.getEmail(), reservationId);
 
 		// then
 		assertThat(canceled.getReservationId()).isEqualTo(reservationId);
@@ -376,166 +405,116 @@ class ReservationServiceTest {
 
 		DailySlotCapacity updated = captor.getValue();
 		assertThat(updated.getCapacityId()).isEqualTo(777L);
-		assertThat(updated.getSlotId()).isEqualTo(slotId);
+		assertThat(updated.getSlotId()).isEqualTo(reservation.getSlotId());
 		assertThat(updated.getDate()).isEqualTo(date);
 		assertThat(updated.getRemainingCount()).isEqualTo(10); // 8 + 2 복구
 
-		verify(reservationRepository, times(1)).save(any(Reservation.class));
+		verify(reservationRepository, times(1)).updateStatus(reservation);
 	}
 
 	@Test
 	@DisplayName("예약 취소 실패 - 본인 예약 아님(403)")
 	void cancel_fail_forbidden() {
 		// given
-		String email = "customer01@test.com";
-		Long userId = 1L;
-		Long otherUserId = 2L;
 		Long reservationId = 999L;
-		Long slotId = 10L;
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime visitAt = now.plusDays(2);
 
-		LocalDateTime visitAt = LocalDateTime.now().plusDays(2);
-
-		User user = createTestUser(userId, email);
-
-		Reservation reservation = Reservation.builder()
+		Reservation reservation = ReservationFixture.confirmed()
 			.reservationId(reservationId)
-			.userId(otherUserId) // 다른 유저 예약
-			.slotId(slotId)
+			.userId(2L) // 다른 유저 예약
+			.slotId(restaurantSlot.getSlotId())
 			.visitAt(visitAt)
 			.partySize(2)
-			.status(ReservationStatus.CONFIRMED)
 			.build();
 
-		given(userRepository.fetchByEmail(email)).willReturn(user);
+		given(userRepository.fetchByEmail(customer.getEmail())).willReturn(customer);
 		given(reservationRepository.fetchById(reservationId)).willReturn(reservation);
 
 		// when & then
-		assertThatThrownBy(() -> reservationService.cancel(email, reservationId))
+		assertThatThrownBy(() -> reservationService.cancel(customer.getEmail(), reservationId))
 			.isInstanceOf(ReservationException.class)
 			.satisfies(ex -> assertThat(((ReservationException)ex).getErrorCode())
 				.isEqualTo(ErrorCode.RESERVATION_FORBIDDEN));
 
 		verifyNoInteractions(dailySlotCapacityRepository);
-		verify(reservationRepository, never()).save(any());
+		verify(reservationRepository, never()).updateStatus(any());
 	}
 
 	@Test
 	@DisplayName("예약 취소 실패 - 이미 취소된 예약(409)")
 	void cancel_fail_alreadyCanceled() {
 		// given
-		String email = "customer01@test.com";
-		Long userId = 1L;
 		Long reservationId = 999L;
-		Long slotId = 10L;
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime visitAt = now.plusDays(2);
 
-		LocalDateTime visitAt = LocalDateTime.now().plusDays(2);
-
-		User user = createTestUser(userId, email);
-
-		Reservation reservation = Reservation.builder()
+		Reservation reservation = ReservationFixture.canceled()
 			.reservationId(reservationId)
-			.userId(userId)
-			.slotId(slotId)
+			.userId(customer.getUserId())
+			.slotId(restaurantSlot.getSlotId())
 			.visitAt(visitAt)
 			.partySize(2)
-			.status(ReservationStatus.CANCELED) // 이미 취소
 			.build();
 
-		given(userRepository.fetchByEmail(email)).willReturn(user);
+		given(userRepository.fetchByEmail(customer.getEmail())).willReturn(customer);
 		given(reservationRepository.fetchById(reservationId)).willReturn(reservation);
 
 		// when & then
-		assertThatThrownBy(() -> reservationService.cancel(email, reservationId))
+		assertThatThrownBy(() -> reservationService.cancel(customer.getEmail(), reservationId))
 			.isInstanceOf(ReservationException.class)
 			.satisfies(ex -> assertThat(((ReservationException)ex).getErrorCode())
 				.isEqualTo(ErrorCode.RESERVATION_ALREADY_CANCELED));
 
 		verifyNoInteractions(dailySlotCapacityRepository);
-		verify(reservationRepository, never()).save(any());
+		verify(reservationRepository, never()).updateStatus(any());
 	}
 
 	@Test
 	@DisplayName("예약 취소 실패 - 취소 가능 기한(24시간) 지남")
 	void cancel_fail_deadlinePassed() {
 		// given
-		String email = "customer01@test.com";
-		Long userId = 1L;
 		Long reservationId = 999L;
-		Long slotId = 10L;
 
 		// visitAt이 현재로부터 24시간 이내면 취소 불가
-		LocalDateTime visitAt = LocalDateTime.now().plusHours(23);
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime visitAt = now.plusHours(23);
 
-		User user = createTestUser(userId, email);
-
-		Reservation reservation = Reservation.builder()
+		Reservation reservation = ReservationFixture.confirmed()
 			.reservationId(reservationId)
-			.userId(userId)
-			.slotId(slotId)
+			.userId(customer.getUserId())
+			.slotId(restaurantSlot.getSlotId())
 			.visitAt(visitAt)
 			.partySize(2)
-			.status(ReservationStatus.CONFIRMED)
 			.build();
 
-		given(userRepository.fetchByEmail(email)).willReturn(user);
+		given(userRepository.fetchByEmail(customer.getEmail())).willReturn(customer);
 		given(reservationRepository.fetchById(reservationId)).willReturn(reservation);
 
 		// when & then
-		assertThatThrownBy(() -> reservationService.cancel(email, reservationId))
+		assertThatThrownBy(() -> reservationService.cancel(customer.getEmail(), reservationId))
 			.isInstanceOf(ReservationException.class)
 			.satisfies(ex -> assertThat(((ReservationException)ex).getErrorCode())
 				.isEqualTo(ErrorCode.RESERVATION_CANCEL_DEADLINE_PASSED));
 
 		verifyNoInteractions(dailySlotCapacityRepository);
-		verify(reservationRepository, never()).save(any());
+		verify(reservationRepository, never()).updateStatus(any());
 	}
 
-	private ReservationSearchDto createSearchDto() {
+	private ReservationSearchDto createSearchDto(
+		LocalDate fromDate,
+		LocalDate toDate,
+		ReservationStatus status
+	) {
 		ReservationSearchDto searchDto = new ReservationSearchDto();
-		searchDto.setFromDate(TEST_DATE);
-		searchDto.setToDate(TEST_DATE);
-		searchDto.setStatus(ReservationStatus.CONFIRMED);
-		searchDto.setPageable(PAGEABLE);
+		searchDto.setFromDate(fromDate);
+		searchDto.setToDate(toDate);
+		searchDto.setStatus(status);
+		searchDto.setPageable(ReservationServiceTest.PAGEABLE);
 		return searchDto;
 	}
 
-	private ReservationListFixture reservationListFixture(
-		Long userId,
-		Long slotId,
-		Long restaurantId
-	) {
-		Reservation confirmed = Reservation.builder()
-			.reservationId(1L)
-			.userId(userId)
-			.slotId(slotId)
-			.visitAt(TEST_VISIT_AT)
-			.partySize(2)
-			.note("confirmed")
-			.status(ReservationStatus.CONFIRMED)
-			.build();
-
-		Page<Reservation> page = new PageImpl<>(List.of(confirmed), PAGEABLE, 2);
-
-		RestaurantSlot slot = RestaurantSlot.builder()
-			.slotId(slotId)
-			.restaurantId(restaurantId)
-			.time(TEST_TIME)
-			.maxCapacity(10)
-			.build();
-
-		Restaurant restaurant = Restaurant.builder()
-			.restaurantId(restaurantId)
-			.name("강남 한상")
-			.build();
-
-		return new ReservationListFixture(page, slot, restaurant);
+	private ReservationRequestDto createReservationRequest(Long slotId, LocalDate date, int partySize, String note) {
+		return new ReservationRequestDto(slotId, date, partySize, note);
 	}
-
-	private record ReservationListFixture(
-		Page<Reservation> page,
-		RestaurantSlot slot,
-		Restaurant restaurant
-	) {
-	}
-
 }

--- a/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.BDDMockito.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -18,17 +17,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 
 import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacity;
 import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacityRepository;
 import com.reservation.tablereservationservice.domain.reservation.Reservation;
 import com.reservation.tablereservationservice.domain.reservation.ReservationRepository;
 import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
-import com.reservation.tablereservationservice.domain.restaurant.Restaurant;
 import com.reservation.tablereservationservice.domain.restaurant.RestaurantRepository;
 import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlot;
 import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlotRepository;
@@ -36,23 +30,17 @@ import com.reservation.tablereservationservice.domain.user.User;
 import com.reservation.tablereservationservice.domain.user.UserRepository;
 import com.reservation.tablereservationservice.fixture.DailySlotCapacityFixture;
 import com.reservation.tablereservationservice.fixture.ReservationFixture;
-import com.reservation.tablereservationservice.fixture.RestaurantFixture;
 import com.reservation.tablereservationservice.fixture.RestaurantSlotFixture;
 import com.reservation.tablereservationservice.fixture.UserFixture;
 import com.reservation.tablereservationservice.global.exception.ErrorCode;
 import com.reservation.tablereservationservice.global.exception.ReservationException;
-import com.reservation.tablereservationservice.global.exception.UserException;
-import com.reservation.tablereservationservice.presentation.common.PageResponseDto;
-import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationListResponseDto;
 import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationRequestDto;
-import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationSearchDto;
 
 @ExtendWith(MockitoExtension.class)
 class ReservationServiceTest {
 
 	private static final LocalDate BASE_DATE = LocalDate.of(2030, 1, 1);
 	private static final LocalTime BASE_TIME = LocalTime.of(19, 0);
-	private static final Pageable PAGEABLE = PageRequest.of(0, 10);
 
 	@Mock
 	private UserRepository userRepository;
@@ -73,7 +61,6 @@ class ReservationServiceTest {
 	private ReservationService reservationService;
 
 	private User customer;
-	private User owner;
 	private RestaurantSlot restaurantSlot;
 
 	@BeforeEach
@@ -81,10 +68,6 @@ class ReservationServiceTest {
 		customer = UserFixture
 			.customer()
 			.userId(1L)
-			.build();
-
-		owner = UserFixture.owner()
-			.userId(2L)
 			.build();
 
 		restaurantSlot = RestaurantSlotFixture.slot()
@@ -107,7 +90,7 @@ class ReservationServiceTest {
 			.remainingCount(10)
 			.build();
 
-		ReservationRequestDto req = createReservationRequest(restaurantSlot.getSlotId(), date, partySize, "note");
+		ReservationRequestDto req = new ReservationRequestDto(restaurantSlot.getSlotId(), date, partySize, "note");
 
 		given(userRepository.fetchByEmail(customer.getEmail())).willReturn(customer);
 		given(restaurantSlotRepository.fetchById(restaurantSlot.getSlotId())).willReturn(restaurantSlot);
@@ -127,96 +110,16 @@ class ReservationServiceTest {
 		assertThat(saved.getUserId()).isEqualTo(customer.getUserId());
 		assertThat(saved.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
 
-		// then - save argument 검증
-		ArgumentCaptor<Reservation> reservationCaptor = ArgumentCaptor.forClass(Reservation.class);
-		verify(reservationRepository).save(reservationCaptor.capture());
+		verify(reservationRepository).save(any(Reservation.class));
 
-		Reservation captured = reservationCaptor.getValue();
-		assertThat(captured.getUserId()).isEqualTo(customer.getUserId());
-		assertThat(captured.getSlotId()).isEqualTo(restaurantSlot.getSlotId());
-		assertThat(captured.getVisitAt()).isEqualTo(visitAt);
-		assertThat(captured.getPartySize()).isEqualTo(partySize);
-		assertThat(captured.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
-
-		// then - capacity 차감 검증
+		// capacity 차감 확인
 		ArgumentCaptor<DailySlotCapacity> capacityCaptor = ArgumentCaptor.forClass(DailySlotCapacity.class);
 		verify(dailySlotCapacityRepository).updateRemainingCount(capacityCaptor.capture());
 		assertThat(capacityCaptor.getValue().getRemainingCount()).isEqualTo(8);
 	}
 
 	@Test
-	@DisplayName("예약 요청 실패 - 유저 없음")
-	void create_fail_userNotFound() {
-		// given
-		ReservationRequestDto req = createReservationRequest(restaurantSlot.getSlotId(), BASE_DATE, 2, "");
-
-		given(userRepository.fetchByEmail(customer.getEmail()))
-			.willThrow(new UserException(ErrorCode.RESOURCE_NOT_FOUND, "User"));
-
-		// when & then
-		assertThatThrownBy(() -> reservationService.create(customer.getEmail(), req))
-			.isInstanceOf(UserException.class);
-
-		verifyNoInteractions(restaurantSlotRepository, dailySlotCapacityRepository, reservationRepository);
-	}
-
-	@Test
-	@DisplayName("예약 요청 실패 - 중복 예약 예외 발생")
-	void create_fail_duplicatedTime_preCheck() {
-		// given
-		LocalDate date = BASE_DATE;
-		LocalDateTime visitAt = LocalDateTime.of(date, restaurantSlot.getTime());
-
-		ReservationRequestDto req = createReservationRequest(restaurantSlot.getSlotId(), date, 2, "");
-
-		given(userRepository.fetchByEmail(customer.getEmail())).willReturn(customer);
-		given(restaurantSlotRepository.fetchById(restaurantSlot.getSlotId())).willReturn(restaurantSlot);
-
-		given(reservationRepository.existsByUserIdAndVisitAtAndStatus(
-			customer.getUserId(), visitAt, ReservationStatus.CONFIRMED
-		)).willReturn(true);
-
-		// when & then
-		assertThatThrownBy(() -> reservationService.create(customer.getEmail(), req))
-			.isInstanceOf(ReservationException.class)
-			.satisfies(ex -> assertThat(((ReservationException)ex).getErrorCode())
-				.isEqualTo(ErrorCode.RESERVATION_DUPLICATED_TIME));
-
-		verifyNoInteractions(dailySlotCapacityRepository);
-		verify(reservationRepository, never()).save(any());
-	}
-
-	@Test
-	@DisplayName("예약 요청 실패 - capacity row 없음(해당 날짜 슬롯 미오픈)")
-	void create_fail_slotNotOpened() {
-		// given
-		LocalDate date = BASE_DATE;
-		LocalDateTime visitAt = LocalDateTime.of(date, restaurantSlot.getTime());
-
-		ReservationRequestDto req = createReservationRequest(restaurantSlot.getSlotId(), date, 2, "");
-
-		given(userRepository.fetchByEmail(customer.getEmail())).willReturn(customer);
-		given(restaurantSlotRepository.fetchById(restaurantSlot.getSlotId())).willReturn(restaurantSlot);
-
-		given(reservationRepository.existsByUserIdAndVisitAtAndStatus(
-			customer.getUserId(), visitAt, ReservationStatus.CONFIRMED
-		)).willReturn(false);
-
-		given(dailySlotCapacityRepository.findBySlotIdAndDate(restaurantSlot.getSlotId(), date))
-			.willReturn(Optional.empty());
-
-		// when & then
-		assertThatThrownBy(() -> reservationService.create(customer.getEmail(), req))
-			.isInstanceOf(ReservationException.class)
-			.satisfies(ex -> assertThat(((ReservationException)ex).getErrorCode())
-				.isEqualTo(ErrorCode.RESERVATION_SLOT_NOT_OPENED));
-
-		verify(reservationRepository, never()).save(any());
-		verify(dailySlotCapacityRepository, never()).updateRemainingCount(any(DailySlotCapacity.class));
-	}
-
-	@Test
-	@DisplayName("예약 요청 실패 - 좌석 부족")
+	@DisplayName("예약 요청 실패 - 좌석이 부족하면 409 예외가 발생한다.")
 	void create_fail_capacityNotEnough() {
 		// given
 		LocalDate date = BASE_DATE;
@@ -228,11 +131,10 @@ class ReservationServiceTest {
 			.remainingCount(1)
 			.build();
 
-		ReservationRequestDto req = createReservationRequest(restaurantSlot.getSlotId(), date, 2, "");
+		ReservationRequestDto req = new ReservationRequestDto(restaurantSlot.getSlotId(), date, 2, "");
 
 		given(userRepository.fetchByEmail(customer.getEmail())).willReturn(customer);
 		given(restaurantSlotRepository.fetchById(restaurantSlot.getSlotId())).willReturn(restaurantSlot);
-
 		given(reservationRepository.existsByUserIdAndVisitAtAndStatus(
 			customer.getUserId(), visitAt, ReservationStatus.CONFIRMED
 		)).willReturn(false);
@@ -251,173 +153,11 @@ class ReservationServiceTest {
 	}
 
 	@Test
-	@DisplayName("사용자 예약 목록 조회 성공 - 검색 조건이 repository 파라미터로 전달된다.")
-	void findMyReservations_success() {
-		// given
-		LocalDate fromDate = BASE_DATE.minusDays(1);
-		LocalDate toDate = BASE_DATE.plusDays(7);
-		ReservationStatus status = ReservationStatus.CONFIRMED;
-
-		ReservationSearchDto searchDto = createSearchDto(fromDate, toDate, status);
-
-		Reservation reservation = ReservationFixture.confirmed()
-			.userId(customer.getUserId())
-			.slotId(restaurantSlot.getSlotId())
-			.visitAt(LocalDateTime.of(BASE_DATE, restaurantSlot.getTime()))
-			.build();
-
-		Page<Reservation> page = new PageImpl<>(List.of(reservation), PAGEABLE, 1);
-
-		Restaurant restaurant = RestaurantFixture.restaurant()
-			.restaurantId(restaurantSlot.getRestaurantId())
-			.name("강남 한상")
-			.build();
-
-		given(userRepository.fetchByEmail(customer.getEmail())).willReturn(customer);
-		given(reservationRepository.findMyReservations(
-			eq(customer.getUserId()),
-			eq(status),
-			eq(fromDate.atStartOfDay()),
-			eq(toDate.atTime(LocalTime.MAX)),
-			eq(PAGEABLE)
-		)).willReturn(page);
-
-		given(restaurantSlotRepository.findAllById(anyList()))
-			.willReturn(List.of(restaurantSlot));
-
-		given(restaurantRepository.findAllById(anyList()))
-			.willReturn(List.of(restaurant));
-
-		// when
-		PageResponseDto<ReservationListResponseDto> result =
-			reservationService.findMyReservations(customer.getEmail(), searchDto);
-
-		// then
-		assertThat(result.getContent()).hasSize(1);
-		assertThat(result.getContent().getFirst().getRestaurantName()).isEqualTo("강남 한상");
-		assertThat(result.getContent().getFirst().getStatus()).isEqualTo(status);
-	}
-
-	@Test
-	@DisplayName("점주 예약 목록 조회 성공 - 검색 조건이 repository 파라미터로 전달된다.")
-	void findOwnerReservations_success() {
-		// given
-		LocalDate fromDate = BASE_DATE.minusDays(1);
-		LocalDate toDate = BASE_DATE.plusDays(7);
-		ReservationStatus status = ReservationStatus.CONFIRMED;
-
-		ReservationSearchDto searchDto = createSearchDto(fromDate, toDate, status);
-
-		Restaurant ownerRestaurant = RestaurantFixture.restaurant()
-			.restaurantId(200L)
-			.ownerId(owner.getUserId())
-			.build();
-
-		RestaurantSlot ownerSlot = RestaurantSlotFixture.slot()
-			.slotId(300L)
-			.restaurantId(ownerRestaurant.getRestaurantId())
-			.time(BASE_TIME)
-			.build();
-
-		Reservation reservation = ReservationFixture.confirmed()
-			.userId(customer.getUserId())
-			.slotId(ownerSlot.getSlotId())
-			.visitAt(LocalDateTime.of(BASE_DATE, ownerSlot.getTime()))
-			.build();
-
-		Page<Reservation> page = new PageImpl<>(List.of(reservation), PAGEABLE, 1);
-
-		given(userRepository.fetchByEmail(owner.getEmail())).willReturn(owner);
-
-		given(restaurantRepository.findAllByOwnerId(owner.getUserId()))
-			.willReturn(List.of(ownerRestaurant));
-
-		given(reservationRepository.findOwnerReservations(
-			eq(List.of(ownerRestaurant.getRestaurantId())),
-			eq(status),
-			eq(fromDate.atStartOfDay()),
-			eq(toDate.atTime(LocalTime.MAX)),
-			eq(PAGEABLE)
-		)).willReturn(page);
-
-		given(restaurantSlotRepository.findAllById(anyList()))
-			.willReturn(List.of(ownerSlot));
-
-		given(restaurantRepository.findAllById(anyList()))
-			.willReturn(List.of(ownerRestaurant));
-
-		given(userRepository.findAllById(anyList()))
-			.willReturn(List.of(customer));
-
-		// when
-		PageResponseDto<ReservationListResponseDto> result =
-			reservationService.findOwnerReservations(owner.getEmail(), searchDto);
-
-		// then
-		assertThat(result.getContent()).hasSize(1);
-		assertThat(result.getContent().getFirst().getRestaurantName()).isEqualTo(ownerRestaurant.getName());
-		assertThat(result.getContent().getFirst().getStatus()).isEqualTo(status);
-
-		verify(restaurantSlotRepository).findAllById(argThat(ids -> ids.contains(300L)));
-		verify(restaurantRepository).findAllById(argThat(ids -> ids.contains(200L)));
-	}
-
-	@Test
-	@DisplayName("예약 취소 성공 - CANCELED 저장 + capacity 복구")
-	void cancel_success() {
-		// given
-		Long reservationId = 999L;
-		int partySize = 2;
-
-		LocalDateTime now = LocalDateTime.now();
-		LocalDateTime visitAt = now.plusDays(2);
-		LocalDate date = visitAt.toLocalDate();
-
-		Reservation reservation = ReservationFixture.confirmed()
-			.reservationId(reservationId)
-			.userId(customer.getUserId())
-			.slotId(restaurantSlot.getSlotId())
-			.visitAt(visitAt)
-			.partySize(partySize)
-			.build();
-
-		DailySlotCapacity capacity = DailySlotCapacityFixture.capacity()
-			.capacityId(777L)
-			.slotId(reservation.getSlotId())
-			.date(date)
-			.remainingCount(8)
-			.build();
-
-		given(userRepository.fetchByEmail(customer.getEmail())).willReturn(customer);
-		given(reservationRepository.fetchById(reservationId)).willReturn(reservation);
-		given(dailySlotCapacityRepository.findBySlotIdAndDate(reservation.getSlotId(), date))
-			.willReturn(Optional.of(capacity));
-
-		// when
-		Reservation canceled = reservationService.cancel(customer.getEmail(), reservationId);
-
-		// then
-		assertThat(canceled.getReservationId()).isEqualTo(reservationId);
-		assertThat(canceled.getStatus()).isEqualTo(ReservationStatus.CANCELED);
-
-		ArgumentCaptor<DailySlotCapacity> captor = ArgumentCaptor.forClass(DailySlotCapacity.class);
-		verify(dailySlotCapacityRepository, times(1)).updateRemainingCount(captor.capture());
-
-		DailySlotCapacity updated = captor.getValue();
-		assertThat(updated.getCapacityId()).isEqualTo(777L);
-		assertThat(updated.getSlotId()).isEqualTo(reservation.getSlotId());
-		assertThat(updated.getDate()).isEqualTo(date);
-		assertThat(updated.getRemainingCount()).isEqualTo(10); // 8 + 2 복구
-
-		verify(reservationRepository, times(1)).updateStatus(reservation);
-	}
-
-	@Test
-	@DisplayName("예약 취소 실패 - 본인 예약 아님(403)")
+	@DisplayName("예약 취소 실패 - 본인 예약이 아니면 403 예외가 발생한다.")
 	void cancel_fail_forbidden() {
 		// given
 		Long reservationId = 999L;
-		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime now = LocalDateTime.now(); // now는 테스트에서 한 번만
 		LocalDateTime visitAt = now.plusDays(2);
 
 		Reservation reservation = ReservationFixture.confirmed()
@@ -442,7 +182,7 @@ class ReservationServiceTest {
 	}
 
 	@Test
-	@DisplayName("예약 취소 실패 - 이미 취소된 예약(409)")
+	@DisplayName("예약 취소 실패 - 이미 취소된 예약이면 400 예외가 발생한다.")
 	void cancel_fail_alreadyCanceled() {
 		// given
 		Long reservationId = 999L;
@@ -471,12 +211,10 @@ class ReservationServiceTest {
 	}
 
 	@Test
-	@DisplayName("예약 취소 실패 - 취소 가능 기한(24시간) 지남")
+	@DisplayName("예약 취소 실패 - 취소 가능 기한(24시간)이 지나면 400 예외가 발생한다.")
 	void cancel_fail_deadlinePassed() {
 		// given
 		Long reservationId = 999L;
-
-		// visitAt이 현재로부터 24시간 이내면 취소 불가
 		LocalDateTime now = LocalDateTime.now();
 		LocalDateTime visitAt = now.plusHours(23);
 
@@ -499,22 +237,5 @@ class ReservationServiceTest {
 
 		verifyNoInteractions(dailySlotCapacityRepository);
 		verify(reservationRepository, never()).updateStatus(any());
-	}
-
-	private ReservationSearchDto createSearchDto(
-		LocalDate fromDate,
-		LocalDate toDate,
-		ReservationStatus status
-	) {
-		ReservationSearchDto searchDto = new ReservationSearchDto();
-		searchDto.setFromDate(fromDate);
-		searchDto.setToDate(toDate);
-		searchDto.setStatus(status);
-		searchDto.setPageable(ReservationServiceTest.PAGEABLE);
-		return searchDto;
-	}
-
-	private ReservationRequestDto createReservationRequest(Long slotId, LocalDate date, int partySize, String note) {
-		return new ReservationRequestDto(slotId, date, partySize, note);
 	}
 }

--- a/src/test/java/com/reservation/tablereservationservice/fixture/DailySlotCapacityFixture.java
+++ b/src/test/java/com/reservation/tablereservationservice/fixture/DailySlotCapacityFixture.java
@@ -3,6 +3,7 @@ package com.reservation.tablereservationservice.fixture;
 import java.time.LocalDate;
 
 import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacity;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,9 +16,9 @@ import lombok.experimental.Accessors;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DailySlotCapacityFixture {
 
-	private Long capacityId = 777L;
+	private Long capacityId = null;
 	private Long slotId = 10L;
-	private LocalDate date = LocalDate.of(2026, 1, 26);
+	private LocalDate date = LocalDate.of(2030, 1, 1);
 	private int remainingCount = 10;
 	private Long version = 0L;
 
@@ -26,12 +27,16 @@ public class DailySlotCapacityFixture {
 	}
 
 	public DailySlotCapacity build() {
-		return DailySlotCapacity.builder()
-			.capacityId(capacityId)
+		DailySlotCapacity.DailySlotCapacityBuilder builder = DailySlotCapacity.builder()
 			.slotId(slotId)
 			.date(date)
 			.remainingCount(remainingCount)
-			.version(version)
-			.build();
+			.version(version);
+
+		if (capacityId != null) {
+			builder.capacityId(capacityId);
+		}
+
+		return builder.build();
 	}
 }

--- a/src/test/java/com/reservation/tablereservationservice/fixture/ReservationFixture.java
+++ b/src/test/java/com/reservation/tablereservationservice/fixture/ReservationFixture.java
@@ -1,0 +1,52 @@
+package com.reservation.tablereservationservice.fixture;
+
+import java.time.LocalDateTime;
+
+import com.reservation.tablereservationservice.domain.reservation.Reservation;
+import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors(fluent = true, chain = true)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReservationFixture {
+
+	private Long reservationId = null;
+	private Long userId = 1L;
+	private Long slotId = 10L;
+
+	private LocalDateTime visitAt = LocalDateTime.of(2030, 1, 1, 19, 0);
+	private int partySize = 2;
+	private String note = "note";
+	private ReservationStatus status = ReservationStatus.CONFIRMED;
+
+	public static ReservationFixture confirmed() {
+		return new ReservationFixture().status(ReservationStatus.CONFIRMED);
+	}
+
+	public static ReservationFixture canceled() {
+		return new ReservationFixture().status(ReservationStatus.CANCELED);
+	}
+
+	public Reservation build() {
+		Reservation.ReservationBuilder builder = Reservation.builder()
+			.userId(userId)
+			.slotId(slotId)
+			.visitAt(visitAt)
+			.partySize(partySize)
+			.note(note)
+			.status(status);
+
+		if (reservationId != null) {
+			builder.reservationId(reservationId);
+		}
+
+		return builder.build();
+	}
+}

--- a/src/test/java/com/reservation/tablereservationservice/fixture/RestaurantFixture.java
+++ b/src/test/java/com/reservation/tablereservationservice/fixture/RestaurantFixture.java
@@ -16,8 +16,8 @@ import lombok.experimental.Accessors;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RestaurantFixture {
 
-	private Long restaurantId = 100L;
-	private String name = "맛집A";
+	private Long restaurantId = null;
+	private String name = "강남 한상";
 	private RegionCode regionCode = RegionCode.RG01;
 	private CategoryCode categoryCode = CategoryCode.CT01;
 	private String address = "서울 강남";
@@ -28,13 +28,17 @@ public class RestaurantFixture {
 	}
 
 	public Restaurant build() {
-		return Restaurant.builder()
-			.restaurantId(restaurantId)
+		Restaurant.RestaurantBuilder builder = Restaurant.builder()
 			.name(name)
 			.regionCode(regionCode)
 			.categoryCode(categoryCode)
 			.address(address)
-			.ownerId(ownerId)
-			.build();
+			.ownerId(ownerId);
+
+		if (restaurantId != null) {
+			builder.restaurantId(restaurantId);
+		}
+
+		return builder.build();
 	}
 }

--- a/src/test/java/com/reservation/tablereservationservice/fixture/RestaurantSlotFixture.java
+++ b/src/test/java/com/reservation/tablereservationservice/fixture/RestaurantSlotFixture.java
@@ -3,6 +3,7 @@ package com.reservation.tablereservationservice.fixture;
 import java.time.LocalTime;
 
 import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlot;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +16,7 @@ import lombok.experimental.Accessors;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RestaurantSlotFixture {
 
-	private Long slotId = 10L;
+	private Long slotId = null;
 	private Long restaurantId = 100L;
 	private LocalTime time = LocalTime.of(19, 0);
 	private int maxCapacity = 10;
@@ -25,11 +26,15 @@ public class RestaurantSlotFixture {
 	}
 
 	public RestaurantSlot build() {
-		return RestaurantSlot.builder()
-			.slotId(slotId)
+		RestaurantSlot.RestaurantSlotBuilder builder = RestaurantSlot.builder()
 			.restaurantId(restaurantId)
 			.time(time)
-			.maxCapacity(maxCapacity)
-			.build();
+			.maxCapacity(maxCapacity);
+
+		if (slotId != null) {
+			builder.slotId(slotId);
+		}
+
+		return builder.build();
 	}
 }

--- a/src/test/java/com/reservation/tablereservationservice/fixture/UserFixture.java
+++ b/src/test/java/com/reservation/tablereservationservice/fixture/UserFixture.java
@@ -15,7 +15,7 @@ import lombok.experimental.Accessors;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserFixture {
 
-	private Long userId = 1L;
+	private Long userId = null;
 	private String email = "customer@test.com";
 	private String name = "user";
 	private String phone = "010-0000-0000";
@@ -39,13 +39,17 @@ public class UserFixture {
 	}
 
 	public User build() {
-		return User.builder()
-			.userId(userId)
+		User.UserBuilder builder = User.builder()
 			.email(email)
 			.name(name)
 			.phone(phone)
 			.password(password)
-			.userRole(userRole)
-			.build();
+			.userRole(userRole);
+
+		if (userId != null) {
+			builder.userId(userId);
+		}
+
+		return builder.build();
 	}
 }


### PR DESCRIPTION
## 개요
- 예약 취소 기능 구현
- 취소 가능 조건(방문 시각 기준 24시간 이전) 검증 로직 추가
- 취소 시 예약 상태 변경 및 좌석(capacity) 복구 처리

## 메인 리뷰어 지정
- 메인 리뷰어 : @blue000927 

## 리뷰 시 참고 사항 
- 라인 수 제한을 지키기 위해, 이번 PR은 예약 취소 기능과 서비스 레이어 단위/통합 테스트까지만 포함했습니다. 컨트롤러 레이어 테스트는 다음 PR로 분리해서 올리겠습니다. 😅
- 현재 작성한 테스트 구조에 대해 아래 관점에서 리뷰 해주시면 감사하겠습니다.
  - 테스트 범위가 과도하지 않은지, 중복 검증이나 불필요한 코드가 존재하지는 않는지
  - 단위 테스트와 통합 테스트 간 역할 분리가 적절한지
  - 가독성과 유지보수 관점에서 더 단순화할 수 있는 구조가 있는지 

## 작업 시 고민사항
- 현재 테스트 코드의 유지보수성과 구조에 대해 많은 고민을 하고 있는 상태입니다. 기능을 하나씩 추가하다 보니, 비즈니스 로직 자체보다 *“이 검증은 어느 레벨에서 책임지는 게 맞을까?”* 라는 고민이 점점 커지고 있습니다.
- 특히 예약 생성/조회/취소 로직이 서로 영향을 주면서 테스트 준비 코드와 검증 포인트가 자연스럽게 늘어나고 있고,  그 과정에서 **단위 테스트와 통합 테스트의 경계가 다소 흐려지고 있는 느낌**도 받고 있습니다.
- 이번 PR에서는 우선 기능의 정확성과 안정성 확보를 목표로 테스트를 작성했지만, 앞으로 기능이 더 추가될 경우 테스트 구조가 계속 증가·변형될 가능성이 있어 지금 시점에서 테스트 구조를 어떻게 가져가는 게 좋은지 방향성에 대한 피드백을 받고 싶습니다.


## TODO
- 예약 취소 기능 컨트롤러 테스트 코드 작성

## References
- <!--사용된 레퍼런스에 대한 링크를 남겨주세요.-->

## 체크리스트
- [x] PR 제목을 명령형으로 작성했습니다.
- [x] PR을 연관되는 github issue에 연결했습니다.
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트 코드가 필요없는 이유가 있습니다.

## 관련 이슈
- closed #9 
