### PR TITLE
좌석 차감 동시성 문제 해결 (synchronized, CAS)

### DIFF
--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/concurrency/CapacityStrategy.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/concurrency/CapacityStrategy.java
@@ -1,0 +1,8 @@
+package com.reservation.tablereservationservice.application.reservation.concurrency;
+
+import java.time.LocalDate;
+
+public interface CapacityStrategy {
+
+	void decrease(Long slotId, LocalDate date, int partySize);
+}

--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/concurrency/cas/AtomicCasCapacityStrategy.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/concurrency/cas/AtomicCasCapacityStrategy.java
@@ -1,0 +1,66 @@
+package com.reservation.tablereservationservice.application.reservation.concurrency.cas;
+
+import java.time.LocalDate;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.stereotype.Component;
+
+import com.reservation.tablereservationservice.application.reservation.concurrency.CapacityStrategy;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.ReservationException;
+
+@Component
+public class AtomicCasCapacityStrategy implements CapacityStrategy {
+
+	private static final int MAX_CAS_RETRY = 50; // 무한 CPU 스핀을 방지하기 위한 상한값
+	private final ConcurrentMap<CapacityKey, AtomicInteger> remainingCache = new ConcurrentHashMap<>();
+
+	public void init(Long slotId, LocalDate date, int initialRemaining) {
+		remainingCache.put(new CapacityKey(slotId, date), new AtomicInteger(initialRemaining));
+	}
+
+	@Override
+	public void decrease(Long slotId, LocalDate date, int partySize) {
+		if (partySize <= 0) {
+			throw new ReservationException(ErrorCode.INVALID_PARTY_SIZE);
+		}
+
+		CapacityKey key = new CapacityKey(slotId, date);
+		AtomicInteger remaining = remainingCache.get(key);
+		if (remaining == null) {
+			throw new IllegalStateException("capacity not initialized: " + key);
+		}
+
+		for (int i = 0; i < MAX_CAS_RETRY; i++) {
+			int current = remaining.get();
+
+			if (current < partySize) {
+				throw new ReservationException(ErrorCode.RESERVATION_CAPACITY_NOT_ENOUGH);
+			}
+
+			if (remaining.compareAndSet(current, current - partySize)) {
+				return;
+			}
+		}
+
+		throw new ReservationException(ErrorCode.RESERVATION_NOT_AVAILABLE, "CAS retry exceeded");
+	}
+
+	public int getRemaining(Long slotId, LocalDate date) {
+		CapacityKey key = new CapacityKey(slotId, date);
+		AtomicInteger remaining = remainingCache.get(key);
+		if (remaining == null) {
+			throw new IllegalStateException("capacity not initialized: " + key);
+		}
+		return remaining.get();
+	}
+
+	public void clear() {
+		remainingCache.clear();
+	}
+
+	public record CapacityKey(Long slotId, LocalDate date) {
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/concurrency/sync/SynchronizedCapacityStrategy.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/concurrency/sync/SynchronizedCapacityStrategy.java
@@ -1,0 +1,35 @@
+package com.reservation.tablereservationservice.application.reservation.concurrency.sync;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Component;
+
+import com.reservation.tablereservationservice.application.reservation.concurrency.CapacityStrategy;
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacity;
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacityRepository;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.ReservationException;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SynchronizedCapacityStrategy implements CapacityStrategy {
+
+	private final DailySlotCapacityRepository dailySlotCapacityRepository;
+	private final Object monitor = new Object();
+
+	@Override
+	public void decrease(Long slotId, LocalDate date, int partySize) {
+		synchronized (monitor) {
+			DailySlotCapacity capacity = dailySlotCapacityRepository.findBySlotIdAndDate(slotId, date)
+				.orElseThrow(() -> new ReservationException(ErrorCode.RESERVATION_SLOT_NOT_OPENED));
+
+			if (!capacity.decrease(partySize)) {
+				throw new ReservationException(ErrorCode.RESERVATION_CAPACITY_NOT_ENOUGH);
+			}
+
+			dailySlotCapacityRepository.updateRemainingCount(capacity);
+		}
+	}
+}

--- a/src/test/java/com/reservation/tablereservationservice/application/reservation/concurrency/cas/AtomicCasCapacityStrategyTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/reservation/concurrency/cas/AtomicCasCapacityStrategyTest.java
@@ -1,0 +1,136 @@
+package com.reservation.tablereservationservice.application.reservation.concurrency.cas;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.ReservationException;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class AtomicCasCapacityStrategyTest {
+
+	@Autowired
+	private AtomicCasCapacityStrategy capacityStrategy;
+
+	private Long slotId;
+	private LocalDate date;
+
+	@BeforeEach
+	void setUp() {
+		capacityStrategy.clear();
+		slotId = 1L;
+		date = LocalDate.now();
+		capacityStrategy.init(slotId, date, 10);
+	}
+
+	@Test
+	@DisplayName("10명이 동시에 1명씩 예약하면 남은 좌석은 0이 된다. (CAS)")
+	void concurrency_test_1() throws InterruptedException {
+		int threadCount = 10;
+
+		ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch ready = new CountDownLatch(threadCount);
+		CountDownLatch start = new CountDownLatch(1);
+		CountDownLatch done = new CountDownLatch(threadCount);
+
+		Queue<Throwable> errors = new ConcurrentLinkedQueue<>();
+		AtomicInteger success = new AtomicInteger();
+		AtomicInteger notEnough = new AtomicInteger();
+
+		for (int i = 0; i < threadCount; i++) {
+			pool.submit(() -> {
+				try {
+					ready.countDown();
+					start.await();
+
+					capacityStrategy.decrease(slotId, date, 1);
+					success.incrementAndGet();
+
+				} catch (ReservationException e) {
+					if (e.getErrorCode() == ErrorCode.RESERVATION_CAPACITY_NOT_ENOUGH) {
+						notEnough.incrementAndGet();
+					} else {
+						errors.add(e);
+					}
+				} catch (Throwable t) {
+					errors.add(t);
+				} finally {
+					done.countDown();
+				}
+			});
+		}
+
+		ready.await();
+		start.countDown();
+		done.await();
+		pool.shutdown();
+
+		assertThat(errors).as("예상 못한 예외 목록").isEmpty();
+		assertThat(notEnough.get()).isEqualTo(0);
+		assertThat(success.get()).isEqualTo(10);
+		assertThat(capacityStrategy.getRemaining(slotId, date)).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("10명이 동시에 2명씩 예약하면 5명은 성공, 5명은 좌석부족이다. (CAS)")
+	void concurrency_test_2() throws InterruptedException {
+		int threadCount = 10;
+
+		ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch ready = new CountDownLatch(threadCount);
+		CountDownLatch start = new CountDownLatch(1);
+		CountDownLatch done = new CountDownLatch(threadCount);
+
+		Queue<Throwable> errors = new ConcurrentLinkedQueue<>();
+		AtomicInteger success = new AtomicInteger();
+		AtomicInteger notEnough = new AtomicInteger();
+
+		for (int i = 0; i < threadCount; i++) {
+			pool.submit(() -> {
+				try {
+					ready.countDown();
+					start.await();
+
+					capacityStrategy.decrease(slotId, date, 2);
+					success.incrementAndGet();
+
+				} catch (ReservationException e) {
+					if (e.getErrorCode() == ErrorCode.RESERVATION_CAPACITY_NOT_ENOUGH) {
+						notEnough.incrementAndGet();
+					} else {
+						errors.add(e);
+					}
+				} catch (Throwable t) {
+					errors.add(t);
+				} finally {
+					done.countDown();
+				}
+			});
+		}
+
+		ready.await();
+		start.countDown();
+		done.await();
+		pool.shutdown();
+
+		assertThat(errors).as("예상 못한 예외 목록").isEmpty();
+		assertThat(success.get()).isEqualTo(5);
+		assertThat(notEnough.get()).isEqualTo(5);
+		assertThat(capacityStrategy.getRemaining(slotId, date)).isEqualTo(0);
+	}
+}

--- a/src/test/java/com/reservation/tablereservationservice/application/reservation/concurrency/sync/SynchronizedCapacityStrategyTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/reservation/concurrency/sync/SynchronizedCapacityStrategyTest.java
@@ -1,0 +1,163 @@
+package com.reservation.tablereservationservice.application.reservation.concurrency.sync;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacity;
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacityRepository;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlot;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlotRepository;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.ReservationException;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class SynchronizedCapacityStrategyTest {
+
+	@Autowired
+	private SynchronizedCapacityStrategy capacityStrategy;
+
+	@Autowired
+	private DailySlotCapacityRepository dailySlotCapacityRepository;
+
+	@Autowired
+	private RestaurantSlotRepository restaurantSlotRepository;
+
+	private Long slotId;
+	private LocalDate date;
+
+	@BeforeEach
+	void setUp() {
+		// 테스트 날짜
+		date = LocalDate.now();
+
+		// 슬롯 생성
+		RestaurantSlot slot = restaurantSlotRepository.save(
+			RestaurantSlot.builder()
+				.restaurantId(1L)
+				.time(LocalTime.of(12, 0))
+				.maxCapacity(10)
+				.build()
+		);
+		slotId = slot.getSlotId();
+
+		// 좌석 수량 생성 (10석)
+		dailySlotCapacityRepository.save(
+			DailySlotCapacity.builder()
+				.slotId(slotId)
+				.date(date)
+				.remainingCount(10)
+				.build()
+		);
+	}
+
+	@Test
+	@DisplayName("10명이 동시에 1명씩 예약하면 남은 좌석은 0이 된다. (synchronized)")
+	void concurrency_test_1() throws InterruptedException {
+		int threadCount = 10;
+
+		ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch ready = new CountDownLatch(threadCount);
+		CountDownLatch start = new CountDownLatch(1);
+		CountDownLatch done = new CountDownLatch(threadCount);
+
+		Queue<Throwable> errors = new ConcurrentLinkedQueue<>();
+
+		for (int i = 0; i < threadCount; i++) {
+			pool.submit(() -> {
+				try {
+					ready.countDown();
+					start.await();
+
+					capacityStrategy.decrease(slotId, date, 1);
+				} catch (Throwable t) {
+					errors.add(t);
+				} finally {
+					done.countDown();
+				}
+			});
+		}
+
+		ready.await();
+		start.countDown();
+		done.await();
+		pool.shutdown();
+
+		assertThat(errors)
+			.as("스레드 내부 예외 목록")
+			.isEmpty();
+
+		DailySlotCapacity result = dailySlotCapacityRepository.findBySlotIdAndDate(slotId, date).orElseThrow();
+		assertThat(result.getRemainingCount()).isEqualTo(0);
+
+	}
+
+	@Test
+	@DisplayName("10명이 동시에 2명씩 예약하면 5명은 성공, 5명은 좌석부족이다. (synchronized)")
+	void concurrency_test_2() throws InterruptedException {
+		int threadCount = 10;
+
+		ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch ready = new CountDownLatch(threadCount);
+		CountDownLatch start = new CountDownLatch(1);
+		CountDownLatch done = new CountDownLatch(threadCount);
+
+		Queue<Throwable> errors = new ConcurrentLinkedQueue<>();
+
+		AtomicInteger success = new AtomicInteger();
+		AtomicInteger notEnough = new AtomicInteger();
+
+		for (int i = 0; i < threadCount; i++) {
+			pool.submit(() -> {
+				try {
+					ready.countDown();
+					start.await();
+
+					capacityStrategy.decrease(slotId, date, 2);
+					success.incrementAndGet();
+
+				} catch (ReservationException e) {
+					if (e.getErrorCode() == ErrorCode.RESERVATION_CAPACITY_NOT_ENOUGH) {
+						notEnough.incrementAndGet();
+					} else {
+						errors.add(e);
+					}
+				} catch (Throwable t) {
+					errors.add(t);
+				} finally {
+					done.countDown();
+				}
+			});
+		}
+
+		ready.await();
+		start.countDown();
+		done.await();
+		pool.shutdown();
+
+		assertThat(errors)
+			.as("예상 못한 예외 목록")
+			.isEmpty();
+
+		assertThat(success.get()).isEqualTo(5);
+		assertThat(notEnough.get()).isEqualTo(5);
+
+		DailySlotCapacity result = dailySlotCapacityRepository.findBySlotIdAndDate(slotId, date).orElseThrow();
+		assertThat(result.getRemainingCount()).isEqualTo(0);
+	}
+}


### PR DESCRIPTION
## 개요
- 예약 좌석 차감 로직에 대해 두 가지(synchronized, cas) 동시성 문제 해결 방법을 구현한다.
- synchronized : JVM 모니터 락 기반의 직관적인 동시성 제어
- CAS(AtomicInteger) : 락 없이 메모리 내 원자성을 활용한 방식
- 동일한 시나리오(10명 동시 요청)를 기준으로 테스트 코드 작성

## 메인 리뷰어 지정
- 메인 리뷰어 : @blue000927 

## 리뷰 시 참고 사항
- 좌석 차감 로직을 CapacityStrategy 인터페이스로 추상화하고, 동시성 제어 방식을 전략 패턴으로 분리했습니다. (향후 다양한 락 기반 전략으로 확장)
- CAS 방식은 메모리 레벨 동시성 제어의 특성을 이해하기 위한 구현이며, 실제 운영 환경에서는 DB 락, Optimistic Lock, Redis Lock 등의 전략이 필요하다고 판단했습니다.

## 실험 결과 및 배운 점
- synchronized 방식
  - 구현이 단순하고, 단일 인스턴스 환경에서는 DB 상태까지 포함해 정합성이 보장되지만, 다중 인스턴스에는 한계가 있다.
- CAS(AtomicInteger) 방식
  - JVM 메모리 내에서는 원자성이 보장되지만, JPA 영속성 컨텍스트 및 DB 상태와는 동기화되지 않는다.
  - 따라서 DB 정합성이 중요한 경우에는 DB 수준의 락이나 버전 관리가 필요할 듯하다.
- synchronized, CAS 모두 다중 인스턴스 환경에서는 완전한 해결책이 아니다. 동시성 전략은 “어디까지 보장해야 하는가(JVM vs DB vs 분산)”에 따라 달라져야 함을 명확히 알 수 있었다.

## TODO
- <!--해당 PR이 머지 된 이후에 챙겨야할 부분을 나열해주세요--> 

## References
- <!--사용된 레퍼런스에 대한 링크를 남겨주세요.-->

## 체크리스트
- [x] PR 제목을 명령형으로 작성했습니다.
- [x] PR을 연관되는 github issue에 연결했습니다.
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트 코드가 필요없는 이유가 있습니다.

## 관련 이슈
- closed #17 
