### PR TITLE
예약 동시성 제어를 위한 락 정책 부하 비교 실험

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out/
 # Spring Boot environment-specific configs
 application-*.yml
 !application.yml
+
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM eclipse-temurin:21-jre
+COPY build/libs/*.jar app.jar
+ENV TZ=Asia/Seoul
+ENTRYPOINT ["java", "-jar", "/app.jar", "--spring.profiles.active=stress-test"]

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+name: table-reservation-service
+
+services:
+  mysql:
+    image: mysql:8.4
+    container_name: trs-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: table-reservation-service
+    ports:
+      - "3307:3306"
+    volumes:
+      - ./db/mysql/data:/var/lib/mysql
+      - ./db/mysql/init:/docker-entrypoint-initdb.d
+    mem_limit: 1g
+    cpus: 1.0
+
+  app:
+    build: .
+    container_name: trs-app
+    depends_on:
+      - mysql
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/table-reservation-service?useSSL=false&allowPublicKeyRetrieval=true
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+    ports:
+      - "8080:8080"
+    mem_limit: 1g
+    cpus: 1.0
+

--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/facade/ReservationOptimisticFacade.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/facade/ReservationOptimisticFacade.java
@@ -1,0 +1,95 @@
+package com.reservation.tablereservationservice.application.reservation.facade;
+
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.retry.support.RetrySynchronizationManager;
+import org.springframework.stereotype.Component;
+
+import com.reservation.tablereservationservice.application.reservation.service.ReservationService;
+import com.reservation.tablereservationservice.domain.reservation.Reservation;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.ReservationException;
+import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationRequestDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ReservationOptimisticFacade {
+
+	private final ReservationService reservationService;
+
+	@Retryable(
+		retryFor = {OptimisticLockingFailureException.class, ObjectOptimisticLockingFailureException.class},
+		maxAttempts = 3,
+		backoff = @Backoff(delay = 20, multiplier = 2.0, maxDelay = 200, random = true)
+	)
+	public Reservation createWithRetry(String email, ReservationRequestDto requestDto, long serverReceivedSeq) {
+		int attempt = getCurrentAttempt();
+
+		if (attempt == 1) {
+			log.info(
+				"[OPT-LOCK] first attempt (seq={}, reqId={}, email={}, slotId={}, date={}, partySize={})",
+				serverReceivedSeq,
+				requestDto.getRequestId(),
+				email,
+				requestDto.getSlotId(),
+				requestDto.getDate(),
+				requestDto.getPartySize()
+			);
+		} else {
+			log.warn(
+				"[OPT-LOCK] retry attempt={} (seq={}, reqId={}, email={})",
+				attempt,
+				serverReceivedSeq,
+				requestDto.getRequestId(),
+				email
+			);
+		}
+
+		return reservationService.create(email, requestDto, serverReceivedSeq);
+	}
+
+	@Recover
+	public Reservation recover(
+		OptimisticLockingFailureException e,
+		String email,
+		ReservationRequestDto requestDto,
+		long serverReceivedSeq
+	) {
+
+		int finalAttempt = getCurrentAttempt();
+
+		log.error(
+			"[OPT-LOCK] retry exhausted (attempt={}, seq={}, reqId={}, email={}, cause={})",
+			finalAttempt, serverReceivedSeq, requestDto.getRequestId(), email, e.getClass().getSimpleName(), e
+		);
+
+		throw new ReservationException(ErrorCode.RESERVATION_CONCURRENCY_ERROR, "재시도 횟수 초과");
+	}
+
+	@Recover
+	public Reservation recover(
+		ReservationException e,
+		String email,
+		ReservationRequestDto requestDto,
+		long serverReceivedSeq
+	) {
+		// 좌석 부족 등은 정상 비즈니스 실패 처리
+		throw e;
+	}
+
+	private int getCurrentAttempt() {
+		RetryContext context = RetrySynchronizationManager.getContext();
+		if (context == null) {
+			return 1;
+		}
+		return context.getRetryCount() + 1;
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/service/ReservationService.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/service/ReservationService.java
@@ -82,6 +82,46 @@ public class ReservationService {
 
 	}
 
+	// 테스트 전용 오버로딩 메서드
+	@Transactional
+	public Reservation create(String email, ReservationRequestDto requestDto, long serverReceivedSeq) {
+		User user = userRepository.fetchByEmail(email);
+
+		RestaurantSlot slot = restaurantSlotRepository.fetchById(requestDto.getSlotId());
+
+		validatePartySize(requestDto.getPartySize(), slot);
+
+		LocalDateTime visitAt = LocalDateTime.of(requestDto.getDate(), slot.getTime());
+
+		// 중복 시간대 예약 검증
+		validateDuplicatedTime(user.getUserId(), visitAt);
+
+		DailySlotCapacity capacity = dailySlotCapacityRepository
+			.findBySlotIdAndDateForUpdate(slot.getSlotId(), requestDto.getDate())
+			.orElseThrow(() -> new ReservationException(ErrorCode.RESERVATION_SLOT_NOT_OPENED));
+
+		// 수량 검증 및 차감
+		decreaseCapacity(capacity, requestDto.getPartySize());
+
+		Reservation reservation = Reservation.builder()
+			.userId(user.getUserId())
+			.slotId(slot.getSlotId())
+			.visitAt(visitAt)
+			.partySize(requestDto.getPartySize())
+			.note(requestDto.getNote())
+			.status(ReservationStatus.CONFIRMED)
+			.requestId(requestDto.getRequestId())
+			.serverReceivedSeq(serverReceivedSeq)
+			.build();
+
+		try {
+			return reservationRepository.save(reservation);
+		} catch (DataIntegrityViolationException e) {
+			throw new ReservationException(ErrorCode.RESERVATION_DUPLICATED_TIME);
+		}
+
+	}
+
 	@Transactional(readOnly = true)
 	public PageResponseDto<ReservationListResponseDto> findMyReservations(
 		String email,

--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/service/ReservationService.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/service/ReservationService.java
@@ -97,7 +97,7 @@ public class ReservationService {
 		validateDuplicatedTime(user.getUserId(), visitAt);
 
 		DailySlotCapacity capacity = dailySlotCapacityRepository
-			.findBySlotIdAndDateForUpdate(slot.getSlotId(), requestDto.getDate())
+			.findBySlotIdAndDate(slot.getSlotId(), requestDto.getDate())
 			.orElseThrow(() -> new ReservationException(ErrorCode.RESERVATION_SLOT_NOT_OPENED));
 
 		// 수량 검증 및 차감

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/DailySlotCapacityRepository.java
@@ -7,6 +7,8 @@ public interface DailySlotCapacityRepository {
 
 	Optional<DailySlotCapacity> findBySlotIdAndDate(Long restaurantSlotId, LocalDate date);
 
+	Optional<DailySlotCapacity> findBySlotIdAndDateForUpdate(Long restaurantSlotId, LocalDate date);
+
 	DailySlotCapacity save(DailySlotCapacity dailySlotCapacity);
 
 	void updateRemainingCount(DailySlotCapacity capacity);

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/Reservation.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/Reservation.java
@@ -15,10 +15,13 @@ public class Reservation {
 	private Integer partySize;
 	private String note;
 	private ReservationStatus status;
+	private String requestId;
+	private long serverReceivedSeq;
 
 	@Builder
 	public Reservation(Long reservationId, Long userId, Long slotId, LocalDateTime visitAt, Integer partySize,
-		String note, ReservationStatus status) {
+		String note, ReservationStatus status, String requestId, long serverReceivedSeq
+	) {
 		this.reservationId = reservationId;
 		this.userId = userId;
 		this.slotId = slotId;
@@ -26,6 +29,8 @@ public class Reservation {
 		this.partySize = partySize;
 		this.note = note;
 		this.status = status;
+		this.requestId = requestId;
+		this.serverReceivedSeq = serverReceivedSeq;
 	}
 
 	public boolean isOwner(Long userId) {

--- a/src/main/java/com/reservation/tablereservationservice/global/config/RetryConfig.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/config/RetryConfig.java
@@ -1,0 +1,10 @@
+package com.reservation.tablereservationservice.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@EnableRetry
+@Configuration
+public class RetryConfig {
+
+}

--- a/src/main/java/com/reservation/tablereservationservice/global/config/SecurityConfig.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/config/SecurityConfig.java
@@ -48,7 +48,8 @@ public class SecurityConfig {
 				.requestMatchers(
 					"/api/users/signup",
 					"/api/users/login",
-					"/api/health"
+					"/api/health",
+					"/api/reservations/test/**"
 				).permitAll()
 				.anyRequest().authenticated()
 			)

--- a/src/main/java/com/reservation/tablereservationservice/global/exception/ErrorCode.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
 	RESERVATION_CAPACITY_NOT_ENOUGH("예약 가능 좌석이 부족합니다.", HttpStatus.CONFLICT),
 	// 동시성 충돌
 	RESERVATION_NOT_AVAILABLE("다른 예약이 선점되었습니다.", HttpStatus.CONFLICT),
+	RESERVATION_CONCURRENCY_ERROR("현재 예약 요청이 많아 처리가 지연되고 있습니다. 잠시 후 다시 시도해주세요.", HttpStatus.CONFLICT),
 
 	// 500 Internal Server Error
 	INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/reservation/tablereservationservice/global/request/RequestSequenceGenerator.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/request/RequestSequenceGenerator.java
@@ -1,0 +1,15 @@
+package com.reservation.tablereservationservice.global.request;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class RequestSequenceGenerator {
+
+	private final AtomicLong seq = new AtomicLong(0);
+
+	public long next() {
+		return seq.incrementAndGet();
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/DailySlotCapacityEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/DailySlotCapacityEntity.java
@@ -43,9 +43,9 @@ public class DailySlotCapacityEntity extends BaseTimeEntity {
 	@Column(nullable = false)
 	private Integer remainingCount;
 
-	// @Version
-	// @Column(nullable = false)
-	// private Long version;
+	@Version
+	@Column(nullable = false)
+	private Long version;
 
 	@Builder
 	public DailySlotCapacityEntity(Long slotId, LocalDate date, Integer remainingCount) {

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/DailySlotCapacityEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/DailySlotCapacityEntity.java
@@ -43,9 +43,9 @@ public class DailySlotCapacityEntity extends BaseTimeEntity {
 	@Column(nullable = false)
 	private Integer remainingCount;
 
-	@Version
-	@Column(nullable = false)
-	private Long version;
+	// @Version
+	// @Column(nullable = false)
+	// private Long version;
 
 	@Builder
 	public DailySlotCapacityEntity(Long slotId, LocalDate date, Integer remainingCount) {

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/ReservationEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/ReservationEntity.java
@@ -55,15 +55,23 @@ public class ReservationEntity extends BaseTimeEntity {
 	@Column(nullable = false, length = 20)
 	private ReservationStatus status;
 
+	@Column(nullable = false)
+	private String requestId;
+
+	@Column(nullable = false)
+	private long serverReceivedSeq;
+
 	@Builder
 	public ReservationEntity(Long userId, Long slotId, LocalDateTime visitAt, Integer partySize,
-		String note, ReservationStatus status) {
+		String note, ReservationStatus status, String requestId, long serverReceivedSeq) {
 		this.userId = userId;
 		this.slotId = slotId;
 		this.visitAt = visitAt;
 		this.partySize = partySize;
 		this.note = note;
 		this.status = status;
+		this.requestId = requestId;
+		this.serverReceivedSeq = serverReceivedSeq;
 	}
 
 	public void updateStatus(ReservationStatus status) {

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/DailySlotCapacityEntityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/DailySlotCapacityEntityRepository.java
@@ -4,11 +4,22 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.reservation.tablereservationservice.infrastructure.reservation.entity.DailySlotCapacityEntity;
+
+import jakarta.persistence.LockModeType;
 
 public interface DailySlotCapacityEntityRepository extends JpaRepository<DailySlotCapacityEntity, Long> {
 
 	Optional<DailySlotCapacityEntity> findBySlotIdAndDate(Long slotSlotId, LocalDate date);
 
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select d from DailySlotCapacityEntity d where d.slotId = :slotId and d.date = :date")
+    Optional<DailySlotCapacityEntity> findBySlotIdAndDateForUpdate(
+        @Param("slotId") Long slotId,
+        @Param("date") LocalDate date
+    );
 }

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaDailySlotCapacityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaDailySlotCapacityRepository.java
@@ -29,6 +29,13 @@ public class JpaDailySlotCapacityRepository implements DailySlotCapacityReposito
 	}
 
 	@Override
+	public Optional<DailySlotCapacity> findBySlotIdAndDateForUpdate(Long slotId, LocalDate date) {
+		return dailySlotCapacityEntityRepository
+			.findBySlotIdAndDateForUpdate(slotId, date)
+			.map(ReservationMapper.INSTANCE::toDomain);
+	}
+
+	@Override
 	public DailySlotCapacity save(DailySlotCapacity dailySlotCapacity) {
 		DailySlotCapacityEntity entity = ReservationMapper.INSTANCE.toEntity(dailySlotCapacity);
 

--- a/src/main/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationController.java
+++ b/src/main/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.reservation.tablereservationservice.application.reservation.facade.ReservationOptimisticFacade;
 import com.reservation.tablereservationservice.application.reservation.service.ReservationService;
 import com.reservation.tablereservationservice.domain.reservation.Reservation;
 import com.reservation.tablereservationservice.global.annotation.CustomerOnly;
@@ -36,6 +37,7 @@ import lombok.RequiredArgsConstructor;
 public class ReservationController {
 
 	private final ReservationService reservationService;
+	private final ReservationOptimisticFacade reservationOptimisticFacade;
 	private final RequestSequenceGenerator sequenceGenerator;
 
 	@CustomerOnly
@@ -50,7 +52,6 @@ public class ReservationController {
 		return ApiResponse.success("예약 요청 성공", responseDto);
 	}
 
-	@Profile("stress-test")
 	@PostMapping("/test")
 	public ApiResponse<ReservationResponseDto> create_test(
 		@Valid @RequestBody ReservationRequestDto requestDto,
@@ -59,7 +60,7 @@ public class ReservationController {
 
 		long serverReceivedSeq = sequenceGenerator.next();
 
-		Reservation reservation = reservationService.create(email, requestDto, serverReceivedSeq);
+		Reservation reservation = reservationOptimisticFacade.createWithRetry(email, requestDto, serverReceivedSeq);
 		ReservationResponseDto responseDto = ReservationResponseDto.from(reservation);
 
 		return ApiResponse.success("예약 요청 성공", responseDto);

--- a/src/main/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationController.java
+++ b/src/main/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationController.java
@@ -1,5 +1,6 @@
 package com.reservation.tablereservationservice.presentation.reservation.controller;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,6 +19,7 @@ import com.reservation.tablereservationservice.global.annotation.CustomerOnly;
 import com.reservation.tablereservationservice.global.annotation.LoginUser;
 import com.reservation.tablereservationservice.global.annotation.OwnerOnly;
 import com.reservation.tablereservationservice.global.common.CurrentUser;
+import com.reservation.tablereservationservice.global.request.RequestSequenceGenerator;
 import com.reservation.tablereservationservice.presentation.common.ApiResponse;
 import com.reservation.tablereservationservice.presentation.common.PageResponseDto;
 import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationListResponseDto;
@@ -33,6 +36,7 @@ import lombok.RequiredArgsConstructor;
 public class ReservationController {
 
 	private final ReservationService reservationService;
+	private final RequestSequenceGenerator sequenceGenerator;
 
 	@CustomerOnly
 	@PostMapping
@@ -41,6 +45,21 @@ public class ReservationController {
 		@LoginUser CurrentUser user
 	) {
 		Reservation reservation = reservationService.create(user.email(), requestDto);
+		ReservationResponseDto responseDto = ReservationResponseDto.from(reservation);
+
+		return ApiResponse.success("예약 요청 성공", responseDto);
+	}
+
+	@Profile("stress-test")
+	@PostMapping("/test")
+	public ApiResponse<ReservationResponseDto> create_test(
+		@Valid @RequestBody ReservationRequestDto requestDto,
+		@RequestHeader("X-User-Email") String email
+	) {
+
+		long serverReceivedSeq = sequenceGenerator.next();
+
+		Reservation reservation = reservationService.create(email, requestDto, serverReceivedSeq);
 		ReservationResponseDto responseDto = ReservationResponseDto.from(reservation);
 
 		return ApiResponse.success("예약 요청 성공", responseDto);

--- a/src/main/java/com/reservation/tablereservationservice/presentation/reservation/dto/ReservationRequestDto.java
+++ b/src/main/java/com/reservation/tablereservationservice/presentation/reservation/dto/ReservationRequestDto.java
@@ -12,6 +12,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ReservationRequestDto {
 
+	private String requestId;
+
 	@NotNull(message = "slotId는 필수입니다.")
 	private Long slotId;
 

--- a/src/main/java/com/reservation/tablereservationservice/presentation/reservation/dto/ReservationResponseDto.java
+++ b/src/main/java/com/reservation/tablereservationservice/presentation/reservation/dto/ReservationResponseDto.java
@@ -15,13 +15,18 @@ public class ReservationResponseDto {
 	private Integer partySize;
 	private ReservationStatus status;
 	private LocalDateTime visitAt;
+	private String requestId;
+	private long serverReceivedSeq;
 
 	@Builder
-	public ReservationResponseDto(Long reservationId, Integer partySize, ReservationStatus status, LocalDateTime visitAt) {
+	public ReservationResponseDto(Long reservationId, Integer partySize, ReservationStatus status, LocalDateTime visitAt,
+		String requestId, long serverReceivedSeq) {
 		this.reservationId = reservationId;
 		this.partySize = partySize;
 		this.status = status;
 		this.visitAt = visitAt;
+		this.requestId = requestId;
+		this.serverReceivedSeq = serverReceivedSeq;
 	}
 
 	public static ReservationResponseDto from(Reservation reservation) {
@@ -30,6 +35,8 @@ public class ReservationResponseDto {
 			.partySize(reservation.getPartySize())
 			.status(reservation.getStatus())
 			.visitAt(reservation.getVisitAt())
+			.requestId(reservation.getRequestId())
+			.serverReceivedSeq(reservation.getServerReceivedSeq())
 			.build();
 	}
 }

--- a/src/main/java/com/reservation/tablereservationservice/script/k6/reservation_fcfs_burst.js
+++ b/src/main/java/com/reservation/tablereservationservice/script/k6/reservation_fcfs_burst.js
@@ -1,0 +1,77 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter } from 'k6/metrics';
+
+const successCounter = new Counter('reservation_success');
+const failCounter = new Counter('reservation_fail');
+
+const BASE_URL = 'http://localhost:8080';
+const RESERVE_URL = `${BASE_URL}/api/reservations/test`;
+
+const SLOT_ID = 1;
+const PARTY_SIZE = 1; // 10개 좌석이므로 10명 성공 기대
+
+export const options = {
+  scenarios: {
+    fcfs_burst: {
+      executor: 'per-vu-iterations',
+      vus: 100,        // 100명 동시 접속
+      iterations: 1,   // 각 유저당 1회 실행
+      maxDuration: '30s',
+    },
+  },
+  thresholds: {
+    // 경합 중에도 95%의 요청은 5초 이내에 완료되어야 함 (비관적 락 대기 시간 고려)
+    http_req_duration: ['p(95)<5000'],
+  },
+};
+
+// 고정된 테스트 날짜 (DB에 입력한 @fcfs_date와 일치해야 함)
+function getTestDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export default function () {
+  const userIndex = __VU; // 1..100
+  const userEmail = `customer${userIndex}@test.com`;
+  const requestId = `req-${userIndex}-${Date.now()}`;
+
+  const payload = JSON.stringify({
+    slotId: SLOT_ID,
+    date: getTestDate(),
+    partySize: PARTY_SIZE,
+    note: 'pessimistic-lock-test',
+    requestId: requestId,
+  });
+
+  const params = {
+    headers: {
+      'Content-Type': 'application/json',
+      'X-User-Email': userEmail,
+    },
+  };
+
+  const res = http.post(RESERVE_URL, payload, params);
+
+  const isSuccess = res.status === 200 || res.status === 201;
+
+  if (isSuccess) {
+    successCounter.add(1);
+  } else {
+    failCounter.add(1);
+  }
+
+  check(res, {
+    'is expected status (200 or 4xx)': (r) => [200, 201, 400, 409].includes(r.status),
+  });
+
+  // 선착순 결과 확인을 위한 로그
+  if (isSuccess) {
+    console.log(`[SUCCESS] User: ${userEmail}, Status: ${res.status}`);
+  }
+  if (res.status !== 200 && res.status !== 201) {
+    console.error(`[ERROR] Status: ${res.status}, Body: ${res.body}`);
+  }
+
+  sleep(0.1);
+}

--- a/src/main/java/com/reservation/tablereservationservice/script/k6/reservation_fcfs_burst.js
+++ b/src/main/java/com/reservation/tablereservationservice/script/k6/reservation_fcfs_burst.js
@@ -40,7 +40,7 @@ export default function () {
     slotId: SLOT_ID,
     date: getTestDate(),
     partySize: PARTY_SIZE,
-    note: 'pessimistic-lock-test',
+    note: 'optimistic-lock-test',
     requestId: requestId,
   });
 
@@ -62,8 +62,8 @@ export default function () {
   }
 
   check(res, {
-    'is expected status (200 or 4xx)': (r) => [200, 201, 400, 409].includes(r.status),
-  });
+     'status is 200/201/409/400': (r) => [200, 201, 400, 409].includes(r.status),
+   });
 
   // 선착순 결과 확인을 위한 로그
   if (isSuccess) {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -39,21 +39,20 @@ VALUES
 SET @fcfs_date := CURDATE();
 SET @load_start_date := DATE_ADD(@fcfs_date, INTERVAL 1 DAY);
 
--- 정합성 테스트용 (Hot Row 1개, 수량 10개)
+-- 정합성 테스트용 (Hot Row 1개, 수량 10개, version 초기값 0)
 INSERT INTO daily_slot_capacity
-(slot_id, date, remaining_count, created_at, modified_at)
+(slot_id, date, remaining_count, version, created_at, modified_at)
 VALUES
-(1, @fcfs_date, 10, @now, @now);
+(1, @fcfs_date, 10, 0, @now, @now);
 
-
--- 지속 부하용 (7일치 생성)
+-- 지속 부하용 (7일치 생성, version 초기값 0)
 INSERT INTO daily_slot_capacity
-(slot_id, date, remaining_count, created_at, modified_at)
+(slot_id, date, remaining_count, version, created_at, modified_at)
 VALUES
-(1, DATE_ADD(@load_start_date, INTERVAL 0 DAY), 10, @now, @now),
-(1, DATE_ADD(@load_start_date, INTERVAL 1 DAY), 10, @now, @now),
-(1, DATE_ADD(@load_start_date, INTERVAL 2 DAY), 10, @now, @now),
-(1, DATE_ADD(@load_start_date, INTERVAL 3 DAY), 10, @now, @now),
-(1, DATE_ADD(@load_start_date, INTERVAL 4 DAY), 10, @now, @now),
-(1, DATE_ADD(@load_start_date, INTERVAL 5 DAY), 10, @now, @now),
-(1, DATE_ADD(@load_start_date, INTERVAL 6 DAY), 10, @now, @now);
+(1, DATE_ADD(@load_start_date, INTERVAL 0 DAY), 10, 0, @now, @now),
+(1, DATE_ADD(@load_start_date, INTERVAL 1 DAY), 10, 0, @now, @now),
+(1, DATE_ADD(@load_start_date, INTERVAL 2 DAY), 10, 0, @now, @now),
+(1, DATE_ADD(@load_start_date, INTERVAL 3 DAY), 10, 0, @now, @now),
+(1, DATE_ADD(@load_start_date, INTERVAL 4 DAY), 10, 0, @now, @now),
+(1, DATE_ADD(@load_start_date, INTERVAL 5 DAY), 10, 0, @now, @now),
+(1, DATE_ADD(@load_start_date, INTERVAL 6 DAY), 10, 0, @now, @now);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,59 @@
+SET @now := NOW();
+
+-- 1. USERS (Owner 1명 + Recursive CTE를 이용한 Customer 100명 생성)
+INSERT INTO users (email, password, name, phone, user_role, created_at, modified_at)
+VALUES ('owner@test.com', '{bcrypt}$2a$10$4tHhbjhE34bJO6KAveAN0uzi8KXBT/Gm9CZo9CB83qvne44R78I/e', 'Owner 1', '010-9999-9999', 'OWNER', @now, @now);
+
+-- Customer 1~100 생성
+INSERT INTO users (email, password, name, phone, user_role, created_at, modified_at)
+WITH RECURSIVE nums AS (
+    SELECT 1 AS n
+    UNION ALL
+    SELECT n + 1 FROM nums WHERE n < 100
+)
+SELECT
+    CONCAT('customer', n, '@test.com'),
+    '{bcrypt}$2a$10$4tHhbjhE34bJO6KAveAN0uzi8KXBT/Gm9CZo9CB83qvne44R78I/e',
+    CONCAT('Customer ', n),
+    CONCAT('010-0000-', LPAD(n, 4, '0')),
+    'CUSTOMER',
+    @now,
+    @now
+FROM nums;
+
+-- RESTAURANT (owner_id = 1 가정)
+INSERT INTO restaurant
+(owner_id, region_code, category_code, name, address, description, main_menu_name, main_menu_price, created_at, modified_at)
+VALUES
+(1, 'RG01', 'CT01', '강남 한상', '서울 강남', 'Load test dummy restaurant', 'Test Menu', 10000, @now, @now);
+
+
+-- RESTAURANT_SLOT (restaurant_id=1)
+INSERT INTO restaurant_slot
+(restaurant_id, time, max_capacity, created_at, modified_at)
+VALUES
+(1, '18:00:00', 10, @now, @now);
+
+
+-- 날짜 변수 정의
+SET @fcfs_date := CURDATE();
+SET @load_start_date := DATE_ADD(@fcfs_date, INTERVAL 1 DAY);
+
+-- 정합성 테스트용 (Hot Row 1개, 수량 10개)
+INSERT INTO daily_slot_capacity
+(slot_id, date, remaining_count, created_at, modified_at)
+VALUES
+(1, @fcfs_date, 10, @now, @now);
+
+
+-- 지속 부하용 (7일치 생성)
+INSERT INTO daily_slot_capacity
+(slot_id, date, remaining_count, created_at, modified_at)
+VALUES
+(1, DATE_ADD(@load_start_date, INTERVAL 0 DAY), 10, @now, @now),
+(1, DATE_ADD(@load_start_date, INTERVAL 1 DAY), 10, @now, @now),
+(1, DATE_ADD(@load_start_date, INTERVAL 2 DAY), 10, @now, @now),
+(1, DATE_ADD(@load_start_date, INTERVAL 3 DAY), 10, @now, @now),
+(1, DATE_ADD(@load_start_date, INTERVAL 4 DAY), 10, @now, @now),
+(1, DATE_ADD(@load_start_date, INTERVAL 5 DAY), 10, @now, @now),
+(1, DATE_ADD(@load_start_date, INTERVAL 6 DAY), 10, @now, @now);


### PR DESCRIPTION
## 개요
- 예약 동시성 제어를 위한 락 정책(낙관적/비관적) 부하 비교 실험 진행

## 메인 리뷰어 지정
- 메인 리뷰어 : @blue000927 

## 리뷰 시 참고 사항
- 선착순 예약 시나리오를 가정하여, 동일한 데이터 셋에서 각 락 방식의 정합성/성능/선착순 보장 특성을 비교했습니다.
- 동시성 제어 로직 자체의 검증에 집중하기 위해, 실험용 환경을 별도로 구성했습니다.
  - 실제 운영 API와 분리된 /api/reservations/test 전용 엔드포인트 구성
  - 인증/인가(JWT, Spring Security) 로직은 최소화하여 순수 비즈니스 로직 경합만 측정
  - 테스트 전용 `serverReceivedSeq` 필드 추가 (선착순 도달 순서 기록용)
- 상세 수치 및 분석은 별도 보고서로 제출합니다.
- [[k6 부하 테스트 결과 보고서 1차] 선착순 예약 시스템 동시성 제어 검증](https://jeondui.notion.site/k6-1-3061b71577cb80e7acfdece64e750614)

## TODO
- <!--해당 PR이 머지 된 이후에 챙겨야할 부분을 나열해주세요--> 

## References
- <!--사용된 레퍼런스에 대한 링크를 남겨주세요.-->

## 체크리스트
- [x] PR 제목을 명령형으로 작성했습니다.
- [x] PR을 연관되는 github issue에 연결했습니다.
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트 코드가 필요없는 이유가 있습니다.

## 관련 이슈
- closed #19 
