### PR TITLE
Toss Payments 결제 연동 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:21-jre
 COPY build/libs/*.jar app.jar
 ENV TZ=Asia/Seoul
-ENTRYPOINT ["java", "-jar", "/app.jar", "--spring.profiles.active=stress-test"]
+ENTRYPOINT ["java", "-jar", "/app.jar", "--spring.profiles.active=dev"]

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
 
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
@@ -53,6 +55,7 @@ dependencies {
     testImplementation "io.rest-assured:json-path"
     testImplementation "io.rest-assured:xml-path"
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/db/mysql/init/schema.sql
+++ b/db/mysql/init/schema.sql
@@ -1,0 +1,108 @@
+CREATE TABLE users (
+    user_id     BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '사용자 PK',
+    email       VARCHAR(100) NOT NULL UNIQUE      COMMENT '이메일',
+    password    VARCHAR(255) NOT NULL             COMMENT '비밀번호',
+    name        VARCHAR(50)  NOT NULL             COMMENT '이름',
+    phone       VARCHAR(20)                       COMMENT '전화번호',
+    user_role   VARCHAR(20)  NOT NULL             COMMENT '사용자 역할',
+    created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
+    modified_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='사용자';
+
+
+CREATE TABLE restaurant (
+    restaurant_id   BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '식당 PK',
+    owner_id        BIGINT       NOT NULL              COMMENT '점주 사용자 FK',
+    region_code     VARCHAR(10)  NOT NULL              COMMENT '지역 코드',
+    category_code   VARCHAR(10)  NOT NULL              COMMENT '카테고리 코드',
+    name            VARCHAR(100) NOT NULL              COMMENT '식당명',
+    address         VARCHAR(255) NOT NULL              COMMENT '주소',
+    description     TEXT                              COMMENT '설명',
+    main_menu_name  VARCHAR(100)                       COMMENT '대표 메뉴명',
+    main_menu_price INT                               COMMENT '대표 메뉴 가격',
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
+    modified_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    CONSTRAINT fk_restaurant_owner
+        FOREIGN KEY (owner_id) REFERENCES users(user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='식당';
+
+
+CREATE TABLE restaurant_slot (
+    slot_id            BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '슬롯 PK',
+    restaurant_id      BIGINT NOT NULL                   COMMENT '식당 FK',
+    time               TIME   NOT NULL                   COMMENT '예약 시간',
+    max_capacity       INT    NOT NULL                   COMMENT '슬롯 최대 수용 인원',
+    deposit_per_person INT    NOT NULL DEFAULT 0          COMMENT '인당 예약금',
+    created_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
+    modified_at        TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    CONSTRAINT fk_slot_restaurant
+        FOREIGN KEY (restaurant_id) REFERENCES restaurant(restaurant_id),
+    CONSTRAINT uq_restaurant_time UNIQUE (restaurant_id, time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='식당 예약 슬롯';
+
+
+CREATE TABLE daily_slot_capacity (
+    capacity_id     BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '일자별 슬롯 수량 PK',
+    slot_id         BIGINT NOT NULL                   COMMENT '슬롯 FK',
+    date            DATE   NOT NULL                   COMMENT '날짜',
+    remaining_count INT    NOT NULL                   COMMENT '잔여 수량',
+    version         BIGINT NOT NULL DEFAULT 0          COMMENT '낙관적 락 버전',
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
+    modified_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    CONSTRAINT fk_capacity_slot
+        FOREIGN KEY (slot_id) REFERENCES restaurant_slot(slot_id),
+    CONSTRAINT uq_slot_date UNIQUE (slot_id, date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='일자별 슬롯 잔여 수량';
+
+
+CREATE TABLE reservation (
+    reservation_id  BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '예약 PK',
+    user_id         BIGINT       NOT NULL              COMMENT '예약자 FK',
+    slot_id         BIGINT       NOT NULL              COMMENT '슬롯 FK',
+    visit_at        DATETIME     NOT NULL              COMMENT '방문 일시',
+    party_size      INT          NOT NULL              COMMENT '예약 인원',
+    note            VARCHAR(255)                       COMMENT '요청 사항',
+    status          VARCHAR(20)  NOT NULL              COMMENT '예약 상태',
+    idempotency_key VARCHAR(36)  UNIQUE                COMMENT '멱등성 키',
+    payment_key     VARCHAR(200)                       COMMENT 'Toss 결제 키 (approve 요청 시 저장)',
+    version         BIGINT       NOT NULL DEFAULT 0    COMMENT '낙관적 락 버전',
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
+    modified_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    CONSTRAINT fk_reservation_user
+        FOREIGN KEY (user_id) REFERENCES users(user_id),
+    CONSTRAINT fk_reservation_slot
+        FOREIGN KEY (slot_id) REFERENCES restaurant_slot(slot_id),
+    INDEX idx_reservation_status_created_at (status, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='예약';
+
+
+CREATE TABLE payment (
+    payment_id      BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '결제 PK',
+    reservation_id  BIGINT       NOT NULL UNIQUE         COMMENT '예약 FK',
+    idempotency_key VARCHAR(36)  NOT NULL UNIQUE         COMMENT '멱등성 키',
+    payment_key     VARCHAR(200) NOT NULL              COMMENT 'Toss 결제 키',
+    amount          INT          NOT NULL              COMMENT '결제 금액',
+    status          VARCHAR(10)  NOT NULL              COMMENT '결제 상태',
+    approved_at     DATETIME     NOT NULL              COMMENT '결제 승인 일시',
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
+    modified_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    CONSTRAINT fk_payment_reservation
+        FOREIGN KEY (reservation_id) REFERENCES reservation(reservation_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='결제';
+
+
+CREATE TABLE notification (
+    notification_id BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '알림 PK',
+    receiver_id     BIGINT       NOT NULL              COMMENT '수신자 FK',
+    reservation_id  BIGINT       NOT NULL              COMMENT '예약 FK',
+    type            VARCHAR(20)  NOT NULL              COMMENT '알림 유형 (CONFIRM/CANCEL/REMINDER)',
+    title           VARCHAR(100) NOT NULL              COMMENT '알림 제목',
+    content         VARCHAR(500) NOT NULL              COMMENT '알림 내용',
+    is_read         TINYINT(1)   NOT NULL DEFAULT 0    COMMENT '읽음 여부',
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
+    modified_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    CONSTRAINT fk_notification_receiver
+        FOREIGN KEY (receiver_id) REFERENCES users(user_id),
+    CONSTRAINT fk_notification_reservation
+        FOREIGN KEY (reservation_id) REFERENCES reservation(reservation_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='알림';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,17 +59,6 @@ services:
       - ./db/mysql/data:/var/lib/mysql
       - ./db/mysql/init:/docker-entrypoint-initdb.d
 
-  mysql-exporter:
-    container_name: mysql-exporter
-    image: prom/mysqld-exporter:latest
-    depends_on:
-      - mysql
-    restart: always
-    volumes:
-      - ./.my.cnf:/.my.cnf
-    ports:
-      - "9104:9104"
-
   redis:
     image: redis:7-alpine
     container_name: redis
@@ -77,6 +66,21 @@ services:
       - "6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  rabbitmq:
+    image: rabbitmq:3-management-alpine
+    container_name: rabbitmq
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/script/monitoring/prometheus.yml
+++ b/script/monitoring/prometheus.yml
@@ -7,10 +7,6 @@ scrape_configs:
     static_configs:
       - targets: ["localhost:9090"]
 
-  - job_name: "mysqld-exporter"
-    static_configs:
-      - targets: ["host.docker.internal:9104"]
-
   - job_name: "java_application"
     metrics_path: '/actuator/prometheus'
     scrape_interval: 5s

--- a/src/main/java/com/reservation/tablereservationservice/application/payment/PaymentClient.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/payment/PaymentClient.java
@@ -3,4 +3,6 @@ package com.reservation.tablereservationservice.application.payment;
 public interface PaymentClient {
 
 	PaymentResult confirm(PaymentRequest request);
+
+	PaymentResult queryByPaymentKey(String paymentKey);
 }

--- a/src/main/java/com/reservation/tablereservationservice/application/payment/PaymentClient.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/payment/PaymentClient.java
@@ -1,0 +1,6 @@
+package com.reservation.tablereservationservice.application.payment;
+
+public interface PaymentClient {
+
+	PaymentResult confirm(PaymentRequest request);
+}

--- a/src/main/java/com/reservation/tablereservationservice/application/payment/PaymentRequest.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/payment/PaymentRequest.java
@@ -1,24 +1,18 @@
 package com.reservation.tablereservationservice.application.payment;
 
-import com.reservation.tablereservationservice.presentation.payment.dto.PaymentConfirmRequestDto;
-
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PaymentRequest {
 
-	private String paymentKey;
-	private String orderId;
-	private Integer amount;
+	private final String paymentKey;
+	private final String orderId;
+	private final Integer amount;
 
-	public static PaymentRequest from(PaymentConfirmRequestDto requestDto) {
-		PaymentRequest request = new PaymentRequest();
-		request.paymentKey = requestDto.getPaymentKey();
-		request.orderId = requestDto.getOrderId();
-		request.amount = requestDto.getAmount();
-		return request;
+	public static PaymentRequest of(String paymentKey, String orderId, Integer amount) {
+		return new PaymentRequest(paymentKey, orderId, amount);
 	}
 }

--- a/src/main/java/com/reservation/tablereservationservice/application/payment/PaymentRequest.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/payment/PaymentRequest.java
@@ -1,0 +1,24 @@
+package com.reservation.tablereservationservice.application.payment;
+
+import com.reservation.tablereservationservice.presentation.payment.dto.PaymentConfirmRequestDto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PaymentRequest {
+
+	private String paymentKey;
+	private String orderId;
+	private Integer amount;
+
+	public static PaymentRequest from(PaymentConfirmRequestDto requestDto) {
+		PaymentRequest request = new PaymentRequest();
+		request.paymentKey = requestDto.getPaymentKey();
+		request.orderId = requestDto.getOrderId();
+		request.amount = requestDto.getAmount();
+		return request;
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/application/payment/PaymentResult.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/payment/PaymentResult.java
@@ -1,0 +1,20 @@
+package com.reservation.tablereservationservice.application.payment;
+
+import java.time.OffsetDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentResult {
+
+	private String paymentKey;
+	private String orderId;
+	private Integer totalAmount;
+	private OffsetDateTime approvedAt;
+}

--- a/src/main/java/com/reservation/tablereservationservice/application/payment/PaymentResult.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/payment/PaymentResult.java
@@ -2,6 +2,8 @@ package com.reservation.tablereservationservice.application.payment;
 
 import java.time.OffsetDateTime;
 
+import com.reservation.tablereservationservice.domain.payment.PaymentStatus;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,4 +19,9 @@ public class PaymentResult {
 	private String orderId;
 	private Integer totalAmount;
 	private OffsetDateTime approvedAt;
+	private String status;
+
+	public boolean isDone() {
+		return PaymentStatus.DONE.name().equals(status);
+	}
 }

--- a/src/main/java/com/reservation/tablereservationservice/application/payment/service/PaymentConfirmationService.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/payment/service/PaymentConfirmationService.java
@@ -1,0 +1,71 @@
+package com.reservation.tablereservationservice.application.payment.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.reservation.tablereservationservice.application.notification.NotificationService;
+import com.reservation.tablereservationservice.domain.payment.Payment;
+import com.reservation.tablereservationservice.domain.payment.PaymentRepository;
+import com.reservation.tablereservationservice.domain.payment.PaymentStatus;
+import com.reservation.tablereservationservice.domain.reservation.Reservation;
+import com.reservation.tablereservationservice.domain.reservation.ReservationRepository;
+import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
+import com.reservation.tablereservationservice.domain.restaurant.Restaurant;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantRepository;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlot;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlotRepository;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.ReservationException;
+import com.reservation.tablereservationservice.global.transaction.TransactionHandler;
+import com.reservation.tablereservationservice.infrastructure.payment.messaging.PaymentQueueMessage;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentConfirmationService {
+
+	private final ReservationRepository reservationRepository;
+	private final PaymentRepository paymentRepository;
+	private final RestaurantSlotRepository restaurantSlotRepository;
+	private final RestaurantRepository restaurantRepository;
+	private final NotificationService notificationService;
+	private final TransactionHandler transactionHandler;
+
+	@Transactional
+	public void confirm(PaymentQueueMessage message) {
+		Reservation reservation = reservationRepository.fetchById(message.getReservationId());
+
+		if (reservation.getStatus() != ReservationStatus.PENDING) {
+			log.warn("[PAYMENT] PENDING이 아닌 예약 확정 시도 — 스케줄러 레이스 컨디션 또는 중복 메시지. status={}, reservationId={}",
+					reservation.getStatus(), reservation.getReservationId());
+			return;
+		}
+
+		reservation.confirm();
+		reservationRepository.updateStatus(reservation);
+
+		paymentRepository.save(Payment.builder()
+				.reservationId(message.getReservationId())
+				.idempotencyKey(message.getIdempotencyKey())
+				.paymentKey(message.getPaymentKey())
+				.amount(message.getAmount())
+				.status(PaymentStatus.DONE)
+				.approvedAt(message.getApprovedAt())
+				.build());
+
+		Restaurant restaurant = findRestaurantBySlotId(reservation.getSlotId());
+
+		// TODO: 알림 발송 타이밍 검토
+		transactionHandler.runAfterCommit(() ->
+				notificationService.notifyConfirmed(reservation, restaurant.getOwnerId(), restaurant.getName()));
+	}
+
+	private Restaurant findRestaurantBySlotId(Long slotId) {
+		RestaurantSlot slot = restaurantSlotRepository.fetchById(slotId);
+		return restaurantRepository.findById(slot.getRestaurantId())
+				.orElseThrow(() -> new ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "Restaurant"));
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/application/payment/service/PaymentService.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/payment/service/PaymentService.java
@@ -1,0 +1,68 @@
+package com.reservation.tablereservationservice.application.payment.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.reservation.tablereservationservice.application.payment.PaymentClient;
+import com.reservation.tablereservationservice.application.payment.PaymentRequest;
+import com.reservation.tablereservationservice.application.payment.PaymentResult;
+import com.reservation.tablereservationservice.domain.reservation.Reservation;
+import com.reservation.tablereservationservice.domain.reservation.ReservationRepository;
+import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlot;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlotRepository;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.PaymentException;
+import com.reservation.tablereservationservice.infrastructure.payment.messaging.PaymentQueueMessage;
+import com.reservation.tablereservationservice.infrastructure.payment.messaging.PaymentQueuePublisher;
+import com.reservation.tablereservationservice.presentation.payment.dto.PaymentConfirmRequestDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+	private final ReservationRepository reservationRepository;
+	private final RestaurantSlotRepository restaurantSlotRepository;
+	private final PaymentClient paymentClient;
+	private final PaymentQueuePublisher paymentQueuePublisher;
+
+	@Transactional(readOnly = true)
+	public void confirmPayment(Long userId, PaymentConfirmRequestDto requestDto) {
+		Reservation reservation = reservationRepository.fetchByIdempotencyKey(requestDto.getOrderId());
+
+		validateOwner(reservation, userId);
+
+		if (reservation.getStatus() == ReservationStatus.CONFIRMED) {
+			return;
+		}
+
+		validatePending(reservation);
+
+		RestaurantSlot slot = restaurantSlotRepository.fetchById(reservation.getSlotId());
+		validateAmount(requestDto.getAmount(), slot, reservation);
+
+		PaymentResult result = paymentClient.confirm(PaymentRequest.from(requestDto));
+		paymentQueuePublisher.publish(PaymentQueueMessage.of(reservation, requestDto.getOrderId(), result));
+	}
+
+	private void validateOwner(Reservation reservation, Long userId) {
+		if (!reservation.isOwner(userId)) {
+			throw new PaymentException(ErrorCode.ACCESS_DENIED);
+		}
+	}
+
+	private void validatePending(Reservation reservation) {
+		if (reservation.getStatus() != ReservationStatus.PENDING) {
+			throw new PaymentException(ErrorCode.PAYMENT_RESERVATION_FAILED);
+		}
+	}
+
+	private void validateAmount(Integer requestedAmount, RestaurantSlot slot, Reservation reservation) {
+		int expectedAmount = slot.depositAmount(reservation.getPartySize());
+		if (!requestedAmount.equals(expectedAmount)) {
+			throw new PaymentException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+		}
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/application/payment/service/PaymentService.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/payment/service/PaymentService.java
@@ -32,7 +32,7 @@ public class PaymentService {
 	private final PaymentClient paymentClient;
 	private final PaymentQueuePublisher paymentQueuePublisher;
 
-	public void confirmPayment(Long userId, PaymentConfirmRequestDto requestDto) {
+	public void approve(Long userId, PaymentConfirmRequestDto requestDto) {
 		Reservation reservation = reservationRepository.fetchByIdempotencyKey(requestDto.getOrderId());
 
 		validateOwner(reservation, userId);

--- a/src/main/java/com/reservation/tablereservationservice/application/payment/service/PaymentService.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/payment/service/PaymentService.java
@@ -1,7 +1,8 @@
 package com.reservation.tablereservationservice.application.payment.service;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
 
 import com.reservation.tablereservationservice.application.payment.PaymentClient;
 import com.reservation.tablereservationservice.application.payment.PaymentRequest;
@@ -17,8 +18,11 @@ import com.reservation.tablereservationservice.infrastructure.payment.messaging.
 import com.reservation.tablereservationservice.infrastructure.payment.messaging.PaymentQueuePublisher;
 import com.reservation.tablereservationservice.presentation.payment.dto.PaymentConfirmRequestDto;
 
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PaymentService {
@@ -28,7 +32,6 @@ public class PaymentService {
 	private final PaymentClient paymentClient;
 	private final PaymentQueuePublisher paymentQueuePublisher;
 
-	@Transactional(readOnly = true)
 	public void confirmPayment(Long userId, PaymentConfirmRequestDto requestDto) {
 		Reservation reservation = reservationRepository.fetchByIdempotencyKey(requestDto.getOrderId());
 
@@ -43,8 +46,23 @@ public class PaymentService {
 		RestaurantSlot slot = restaurantSlotRepository.fetchById(reservation.getSlotId());
 		validateAmount(requestDto.getAmount(), slot, reservation);
 
-		PaymentResult result = paymentClient.confirm(PaymentRequest.from(requestDto));
-		paymentQueuePublisher.publish(PaymentQueueMessage.of(reservation, requestDto.getOrderId(), result));
+		reservation.recordPaymentKey(requestDto.getPaymentKey());
+		reservationRepository.updatePaymentKey(reservation);
+
+		PaymentResult result = requestApproval(PaymentRequest.of(requestDto.getPaymentKey(), requestDto.getOrderId(), requestDto.getAmount()));
+		paymentQueuePublisher.publish(PaymentQueueMessage.ofConfirmed(reservation, requestDto.getOrderId(), result));
+	}
+
+	private PaymentResult requestApproval(PaymentRequest request) {
+		try {
+			return paymentClient.confirm(request);
+		} catch (CallNotPermittedException e) {
+			log.warn("[CIRCUIT_BREAKER] 서킷 오픈 — 결제 차단 orderId={}", request.getOrderId());
+			throw new PaymentException(ErrorCode.TOSS_API_UNAVAILABLE);
+		} catch (HttpServerErrorException | ResourceAccessException e) {
+			log.error("[TOSS] 결제 승인 실패 orderId={}", request.getOrderId(), e);
+			throw new PaymentException(ErrorCode.TOSS_API_UNAVAILABLE);
+		}
 	}
 
 	private void validateOwner(Reservation reservation, Long userId) {

--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/aspect/ReservationIdempotencyAspect.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/aspect/ReservationIdempotencyAspect.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.core.annotation.Order;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -19,11 +20,14 @@ import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlot;
 import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlotRepository;
 import com.reservation.tablereservationservice.global.exception.ErrorCode;
 import com.reservation.tablereservationservice.global.exception.ReservationException;
-import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationRequestDto;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * @Idempotent 어노테이션 처리 AOP
+ * DB 유니크 제약(orders.idempotency_key)이 최종 방어선으로 동작한다.
+ */
 @Aspect
 @Component
 @Order(1)
@@ -32,16 +36,20 @@ import lombok.extern.slf4j.Slf4j;
 public class ReservationIdempotencyAspect {
 
 	private static final String PREFIX = "reservation:idempotency:";
-	private static final Duration PROCESSING_TTL = Duration.ofSeconds(30);
-	private static final Duration RESULT_TTL = Duration.ofHours(24);
+	private static final Duration PROCESSING_TTL = Duration.ofSeconds(30); // 동시에 들어온 중복 요청을 막는 용도
+	private static final Duration RESULT_TTL = Duration.ofHours(24); // 성공 결과 캐싱
 
 	private final StringRedisTemplate redisTemplate;
 	private final ReservationRepository reservationRepository;
 	private final RestaurantSlotRepository restaurantSlotRepository;
 	private final ObjectMapper objectMapper;
 
-	@Around("execution(* com.reservation.tablereservationservice.application.reservation.service.ReservationService.reserve(..)) && args(email, requestDto, idempotencyKey)")
-	public Object around(ProceedingJoinPoint joinPoint, String email, ReservationRequestDto requestDto, String idempotencyKey) throws Throwable {
+	@Pointcut("@annotation(com.reservation.tablereservationservice.global.annotation.Idempotent)")
+	private void idempotentOperation() {
+	}
+
+	@Around("idempotentOperation() && args(.., idempotencyKey)")
+	public Object enforceIdempotency(ProceedingJoinPoint joinPoint, String idempotencyKey) throws Throwable {
 		String redisKey = PREFIX + idempotencyKey;
 
 		Boolean acquired = redisTemplate.opsForValue().setIfAbsent(redisKey, "PROCESSING", PROCESSING_TTL);
@@ -49,10 +57,17 @@ public class ReservationIdempotencyAspect {
 		if (Boolean.FALSE.equals(acquired)) {
 			String cached = redisTemplate.opsForValue().get(redisKey);
 			if (cached != null && !"PROCESSING".equals(cached)) {
-				return buildFromCache(cached);
+				try {
+					return buildFromCache(cached);
+				} catch (Exception e) {
+					log.error("[IDEMPOTENCY] 캐시 역직렬화 실패 — 캐시 삭제 후 재처리 idempotencyKey={}", idempotencyKey, e);
+					redisTemplate.delete(redisKey);
+					// 아래 proceed()로 fall-through하여 새 요청으로 처리
+				}
+			} else {
+				// PROCESSING 상태(동시 진입) — DataIntegrityViolationException 안전망으로 처리
+				log.warn("[IDEMPOTENCY] 동시 요청 감지 idempotencyKey={}", idempotencyKey);
 			}
-			// PROCESSING 상태(동시 진입) — 서비스까지 진행시켜 DataIntegrityViolationException 안전망으로 처리
-			log.warn("[IDEMPOTENCY] 동시 요청 감지 idempotencyKey={}", idempotencyKey);
 		}
 
 		try {
@@ -60,7 +75,6 @@ public class ReservationIdempotencyAspect {
 			cacheResult(redisKey, result);
 			return result;
 		} catch (DataIntegrityViolationException e) {
-			// 트랜잭션 rollback 완료 → runOnRollback이 Redis 좌석 복원 처리
 			// 먼저 성공한 요청의 예약을 idempotency key로 조회해 반환
 			return resolveFromDb(redisKey, idempotencyKey);
 		} catch (Throwable t) {
@@ -78,16 +92,11 @@ public class ReservationIdempotencyAspect {
 		return result;
 	}
 
-	private ReservationCreateResult buildFromCache(String cached) {
-		try {
-			ReservationIdempotencyCache dto = objectMapper.readValue(cached, ReservationIdempotencyCache.class);
-			Reservation reservation = reservationRepository.fetchById(dto.reservationId());
-			RestaurantSlot slot = restaurantSlotRepository.fetchById(reservation.getSlotId());
-			return new ReservationCreateResult(reservation, slot.depositAmount(reservation.getPartySize()));
-		} catch (Exception e) {
-			log.error("[IDEMPOTENCY] 캐시 역직렬화 실패", e);
-			throw new ReservationException(ErrorCode.RESERVATION_CONCURRENCY_ERROR);
-		}
+	private ReservationCreateResult buildFromCache(String cached) throws Exception {
+		ReservationIdempotencyCache dto = objectMapper.readValue(cached, ReservationIdempotencyCache.class);
+		Reservation reservation = reservationRepository.fetchById(dto.reservationId());
+		RestaurantSlot slot = restaurantSlotRepository.fetchById(reservation.getSlotId());
+		return new ReservationCreateResult(reservation, slot.depositAmount(reservation.getPartySize()));
 	}
 
 	private void cacheResult(String redisKey, ReservationCreateResult result) {

--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/facade/ReservationFacade.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/facade/ReservationFacade.java
@@ -1,0 +1,29 @@
+package com.reservation.tablereservationservice.application.reservation.facade;
+
+import com.reservation.tablereservationservice.application.reservation.service.ReservationCreateResult;
+import com.reservation.tablereservationservice.application.reservation.service.ReservationService;
+import com.reservation.tablereservationservice.global.annotation.Idempotent;
+import com.reservation.tablereservationservice.infrastructure.redis.ReservationPublisher;
+import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationRequestDto;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationFacade {
+
+	private final ReservationService reservationService;
+	private final ReservationPublisher reservationPublisher;
+
+	@Idempotent
+	public ReservationCreateResult reserve(String email, ReservationRequestDto requestDto, String idempotencyKey) {
+		reservationPublisher.holdSeat(requestDto.getSlotId(), requestDto.getDate(), requestDto.getPartySize());
+		try {
+			return reservationService.reserve(email, requestDto, idempotencyKey);
+		} catch (Exception e) {
+			reservationPublisher.releaseSeat(requestDto.getSlotId(), requestDto.getDate(), requestDto.getPartySize());
+			throw e;
+		}
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/scheduler/PendingReservationExpireScheduler.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/scheduler/PendingReservationExpireScheduler.java
@@ -7,6 +7,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacityRepository;
 import com.reservation.tablereservationservice.domain.reservation.Reservation;
 import com.reservation.tablereservationservice.domain.reservation.ReservationRepository;
 import com.reservation.tablereservationservice.global.config.ReservationStreamProperties;
@@ -21,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PendingReservationExpireScheduler {
 
 	private final ReservationRepository reservationRepository;
+	private final DailySlotCapacityRepository dailySlotCapacityRepository;
 	private final ReservationPublisher reservationPublisher;
 	private final ReservationStreamProperties streamProperties;
 
@@ -38,6 +40,14 @@ public class PendingReservationExpireScheduler {
 		for (Reservation reservation : expired) {
 			reservation.fail();
 			reservationRepository.updateStatus(reservation);
+
+			dailySlotCapacityRepository
+					.findBySlotIdAndDate(reservation.getSlotId(), reservation.getVisitAt().toLocalDate())
+					.ifPresent(capacity -> {
+						capacity.increase(reservation.getPartySize());
+						dailySlotCapacityRepository.updateRemainingCount(capacity);
+					});
+
 			reservationPublisher.releaseSeat(
 					reservation.getSlotId(),
 					reservation.getVisitAt().toLocalDate(),

--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/scheduler/PendingReservationExpireScheduler.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/scheduler/PendingReservationExpireScheduler.java
@@ -53,12 +53,12 @@ public class PendingReservationExpireScheduler {
 			return;
 		}
 
-		if (!tryRecoverFromToss(reservation)) {
+		if (!recoverIfApproved(reservation)) {
 			failReservation(reservation);
 		}
 	}
 
-	private boolean tryRecoverFromToss(Reservation reservation) {
+	private boolean recoverIfApproved(Reservation reservation) {
 		try {
 			PaymentResult result = paymentClient.queryByPaymentKey(reservation.getPaymentKey());
 			if (!result.isDone()) {

--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/scheduler/PendingReservationExpireScheduler.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/scheduler/PendingReservationExpireScheduler.java
@@ -2,15 +2,20 @@ package com.reservation.tablereservationservice.application.reservation.schedule
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
+import com.reservation.tablereservationservice.application.payment.PaymentClient;
+import com.reservation.tablereservationservice.application.payment.PaymentResult;
 import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacityRepository;
 import com.reservation.tablereservationservice.domain.reservation.Reservation;
 import com.reservation.tablereservationservice.domain.reservation.ReservationRepository;
 import com.reservation.tablereservationservice.global.config.ReservationStreamProperties;
+import com.reservation.tablereservationservice.global.exception.PaymentException;
+import com.reservation.tablereservationservice.infrastructure.payment.messaging.PaymentQueueMessage;
+import com.reservation.tablereservationservice.infrastructure.payment.messaging.PaymentQueuePublisher;
 import com.reservation.tablereservationservice.infrastructure.redis.ReservationPublisher;
 
 import lombok.RequiredArgsConstructor;
@@ -25,36 +30,67 @@ public class PendingReservationExpireScheduler {
 	private final DailySlotCapacityRepository dailySlotCapacityRepository;
 	private final ReservationPublisher reservationPublisher;
 	private final ReservationStreamProperties streamProperties;
+	private final PaymentClient paymentClient;
+	private final PaymentQueuePublisher paymentQueuePublisher;
 
-	@Scheduled(fixedDelayString = "${redis.reservation.pending-key-ttl-seconds:900}000")
-	@Transactional
+	@Scheduled(fixedDelayString = "${redis.reservation.pending-expire-scheduler-seconds}", timeUnit = TimeUnit.SECONDS)
 	public void expirePendingReservations() {
-		int ttlSeconds = streamProperties.getPendingKeyTtlSeconds();
-		LocalDateTime threshold = LocalDateTime.now().minusSeconds(ttlSeconds);
-
+		LocalDateTime threshold = LocalDateTime.now().minusSeconds(streamProperties.getPendingExpireThresholdSeconds());
 		List<Reservation> expired = reservationRepository.findPendingBefore(threshold);
+
 		if (expired.isEmpty()) {
 			return;
 		}
 
-		for (Reservation reservation : expired) {
-			reservation.fail();
-			reservationRepository.updateStatus(reservation);
+		expired.forEach(this::processExpiredReservation);
+		log.info("[EXPIRE_SCHEDULER] 만료 처리 완료 count={}", expired.size());
+	}
 
-			dailySlotCapacityRepository
-					.findBySlotIdAndDate(reservation.getSlotId(), reservation.getVisitAt().toLocalDate())
-					.ifPresent(capacity -> {
-						capacity.increase(reservation.getPartySize());
-						dailySlotCapacityRepository.updateRemainingCount(capacity);
-					});
-
-			reservationPublisher.releaseSeat(
-					reservation.getSlotId(),
-					reservation.getVisitAt().toLocalDate(),
-					reservation.getPartySize()
-			);
+	private void processExpiredReservation(Reservation reservation) {
+		if (reservation.getPaymentKey() == null) {
+			log.info("[EXPIRE_SCHEDULER] 결제 시도 없이 만료 reservationId={}", reservation.getReservationId());
+			failReservation(reservation);
+			return;
 		}
 
-		log.info("[EXPIRE_SCHEDULER] PENDING 예약 만료 처리 count={}", expired.size());
+		if (!tryRecoverFromToss(reservation)) {
+			failReservation(reservation);
+		}
+	}
+
+	private boolean tryRecoverFromToss(Reservation reservation) {
+		try {
+			PaymentResult result = paymentClient.queryByPaymentKey(reservation.getPaymentKey());
+			if (!result.isDone()) {
+				return false;
+			}
+			paymentQueuePublisher.publish(
+					PaymentQueueMessage.ofConfirmed(reservation, reservation.getIdempotencyKey(), result));
+			log.info("[EXPIRE_SCHEDULER] 결제 확인으로 예약 복구 reservationId={}", reservation.getReservationId());
+			return true;
+		} catch (PaymentException e) {
+			log.warn("[EXPIRE_SCHEDULER] Toss 조회 실패 — 만료 처리 reservationId={}", reservation.getReservationId());
+			return false;
+		}
+	}
+
+	private void failReservation(Reservation reservation) {
+		reservation.fail();
+		reservationRepository.updateStatus(reservation);
+
+		dailySlotCapacityRepository
+				.findBySlotIdAndDate(reservation.getSlotId(), reservation.getVisitAt().toLocalDate())
+				.ifPresent(capacity -> {
+					capacity.increase(reservation.getPartySize());
+					dailySlotCapacityRepository.updateRemainingCount(capacity);
+				});
+
+		reservationPublisher.releaseSeat(
+				reservation.getSlotId(),
+				reservation.getVisitAt().toLocalDate(),
+				reservation.getPartySize()
+		);
+
+		log.info("[EXPIRE_SCHEDULER] 예약 만료 처리 reservationId={}", reservation.getReservationId());
 	}
 }

--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/scheduler/PendingReservationExpireScheduler.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/scheduler/PendingReservationExpireScheduler.java
@@ -1,0 +1,50 @@
+package com.reservation.tablereservationservice.application.reservation.scheduler;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.reservation.tablereservationservice.domain.reservation.Reservation;
+import com.reservation.tablereservationservice.domain.reservation.ReservationRepository;
+import com.reservation.tablereservationservice.global.config.ReservationStreamProperties;
+import com.reservation.tablereservationservice.infrastructure.redis.ReservationPublisher;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PendingReservationExpireScheduler {
+
+	private final ReservationRepository reservationRepository;
+	private final ReservationPublisher reservationPublisher;
+	private final ReservationStreamProperties streamProperties;
+
+	@Scheduled(fixedDelayString = "${redis.reservation.pending-key-ttl-seconds:900}000")
+	@Transactional
+	public void expirePendingReservations() {
+		int ttlSeconds = streamProperties.getPendingKeyTtlSeconds();
+		LocalDateTime threshold = LocalDateTime.now().minusSeconds(ttlSeconds);
+
+		List<Reservation> expired = reservationRepository.findPendingBefore(threshold);
+		if (expired.isEmpty()) {
+			return;
+		}
+
+		for (Reservation reservation : expired) {
+			reservation.fail();
+			reservationRepository.updateStatus(reservation);
+			reservationPublisher.releaseSeat(
+					reservation.getSlotId(),
+					reservation.getVisitAt().toLocalDate(),
+					reservation.getPartySize()
+			);
+		}
+
+		log.info("[EXPIRE_SCHEDULER] PENDING 예약 만료 처리 count={}", expired.size());
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/scheduler/RedisReconciliationScheduler.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/scheduler/RedisReconciliationScheduler.java
@@ -1,0 +1,41 @@
+package com.reservation.tablereservationservice.application.reservation.scheduler;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacity;
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacityRepository;
+import com.reservation.tablereservationservice.global.config.ReservationStreamProperties;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisReconciliationScheduler {
+
+	private final DailySlotCapacityRepository dailySlotCapacityRepository;
+	private final StringRedisTemplate redisTemplate;
+	private final ReservationStreamProperties streamProperties;
+
+	@Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시
+	public void syncCapacityToRedis() {
+		List<DailySlotCapacity> capacities = dailySlotCapacityRepository.findAllFromDate(LocalDate.now());
+		if (capacities.isEmpty()) {
+			return;
+		}
+
+		for (DailySlotCapacity capacity : capacities) {
+			String key = streamProperties.remainingKey(capacity.getSlotId(), capacity.getDate().toString());
+			redisTemplate.opsForValue().set(key, String.valueOf(capacity.getRemainingCount()), 7, TimeUnit.DAYS);
+		}
+
+		log.info("[REDIS_RECONCILE] Redis 좌석 재동기화 완료 count={}", capacities.size());
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/service/ReservationService.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/service/ReservationService.java
@@ -27,7 +27,7 @@ import com.reservation.tablereservationservice.domain.user.UserRepository;
 import com.reservation.tablereservationservice.global.exception.ErrorCode;
 import com.reservation.tablereservationservice.global.exception.ReservationException;
 import com.reservation.tablereservationservice.global.transaction.TransactionHandler;
-import com.reservation.tablereservationservice.infrastructure.stream.ReservationPublisher;
+import com.reservation.tablereservationservice.infrastructure.redis.ReservationPublisher;
 import com.reservation.tablereservationservice.presentation.common.PageResponseDto;
 import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationListResponseDto;
 import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationRequestDto;

--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/service/ReservationService.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/service/ReservationService.java
@@ -27,7 +27,6 @@ import com.reservation.tablereservationservice.domain.user.UserRepository;
 import com.reservation.tablereservationservice.global.exception.ErrorCode;
 import com.reservation.tablereservationservice.global.exception.ReservationException;
 import com.reservation.tablereservationservice.global.transaction.TransactionHandler;
-import com.reservation.tablereservationservice.infrastructure.redis.ReservationPublisher;
 import com.reservation.tablereservationservice.presentation.common.PageResponseDto;
 import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationListResponseDto;
 import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationRequestDto;
@@ -46,7 +45,6 @@ public class ReservationService {
 	private final DailySlotCapacityRepository dailySlotCapacityRepository;
 	private final ReservationRepository reservationRepository;
 	private final RestaurantRepository restaurantRepository;
-	private final ReservationPublisher reservationPublisher;
 	private final NotificationService notificationService;
 	private final TransactionHandler transactionHandler;
 
@@ -56,12 +54,7 @@ public class ReservationService {
 		RestaurantSlot slot = restaurantSlotRepository.fetchById(requestDto.getSlotId());
 		LocalDateTime visitAt = LocalDateTime.of(requestDto.getDate(), slot.getTime());
 
-		validatePartySize(requestDto.getPartySize(), slot);
 		validateDuplicatedTime(user.getUserId(), visitAt);
-
-		reservationPublisher.holdSeat(slot.getSlotId(), requestDto.getDate(), requestDto.getPartySize());
-		transactionHandler.runOnRollback(() ->
-				reservationPublisher.releaseSeat(slot.getSlotId(), requestDto.getDate(), requestDto.getPartySize()));
 
 		DailySlotCapacity capacity = dailySlotCapacityRepository
 				.findBySlotIdAndDate(slot.getSlotId(), requestDto.getDate())
@@ -78,8 +71,8 @@ public class ReservationService {
 				.status(ReservationStatus.PENDING)
 				.build();
 
-		reservationRepository.save(reservation);
-		return new ReservationCreateResult(reservation, slot.depositAmount(requestDto.getPartySize()));
+		Reservation saved = reservationRepository.save(reservation);
+		return new ReservationCreateResult(saved, slot.depositAmount(requestDto.getPartySize()));
 	}
 
 	@Transactional(readOnly = true)
@@ -158,12 +151,6 @@ public class ReservationService {
 		if (reservationRepository.existsByUserIdAndVisitAtAndStatusIn(
 				userId, visitAt, List.of(ReservationStatus.PENDING, ReservationStatus.CONFIRMED))) {
 			throw new ReservationException(ErrorCode.RESERVATION_DUPLICATED_TIME);
-		}
-	}
-
-	private void validatePartySize(int partySize, RestaurantSlot slot) {
-		if (!slot.canAcceptPartySize(partySize)) {
-			throw new ReservationException(ErrorCode.INVALID_PARTY_SIZE);
 		}
 	}
 

--- a/src/main/java/com/reservation/tablereservationservice/domain/payment/Payment.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/payment/Payment.java
@@ -1,0 +1,37 @@
+package com.reservation.tablereservationservice.domain.payment;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Payment {
+
+	private Long paymentId;
+	private Long reservationId;
+	private String idempotencyKey;
+	private String paymentKey;
+	private Integer amount;
+	private PaymentStatus status;
+	private LocalDateTime approvedAt;
+
+	@Builder
+	public Payment(
+			Long paymentId,
+			Long reservationId,
+			String idempotencyKey,
+			String paymentKey,
+			Integer amount,
+			PaymentStatus status,
+			LocalDateTime approvedAt
+	) {
+		this.paymentId = paymentId;
+		this.reservationId = reservationId;
+		this.idempotencyKey = idempotencyKey;
+		this.paymentKey = paymentKey;
+		this.amount = amount;
+		this.status = status;
+		this.approvedAt = approvedAt;
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/domain/payment/PaymentRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/payment/PaymentRepository.java
@@ -1,0 +1,6 @@
+package com.reservation.tablereservationservice.domain.payment;
+
+public interface PaymentRepository {
+
+	Payment save(Payment payment);
+}

--- a/src/main/java/com/reservation/tablereservationservice/domain/payment/PaymentStatus.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/payment/PaymentStatus.java
@@ -1,0 +1,9 @@
+package com.reservation.tablereservationservice.domain.payment;
+
+import lombok.Getter;
+
+@Getter
+public enum PaymentStatus {
+	DONE,
+	FAILED
+}

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/Reservation.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/Reservation.java
@@ -16,6 +16,7 @@ public class Reservation {
 	private String note;
 	private ReservationStatus status;
 	private String idempotencyKey;
+	private String paymentKey;
 
 	@Builder
 	public Reservation(
@@ -26,7 +27,8 @@ public class Reservation {
 			Integer partySize,
 			String note,
 			ReservationStatus status,
-			String idempotencyKey
+			String idempotencyKey,
+			String paymentKey
 	) {
 		this.reservationId = reservationId;
 		this.userId = userId;
@@ -36,6 +38,11 @@ public class Reservation {
 		this.note = note;
 		this.status = status;
 		this.idempotencyKey = idempotencyKey;
+		this.paymentKey = paymentKey;
+	}
+
+	public void recordPaymentKey(String paymentKey) {
+		this.paymentKey = paymentKey;
 	}
 
 	public void confirm() {
@@ -66,5 +73,4 @@ public class Reservation {
 	public void cancel() {
 		this.status = ReservationStatus.CANCELED;
 	}
-
 }

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/ReservationRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/ReservationRepository.java
@@ -39,6 +39,8 @@ public interface ReservationRepository {
 
 	void updateStatus(Reservation reservation);
 
+	void updatePaymentKey(Reservation reservation);
+
 	List<Reservation> findPendingBefore(LocalDateTime createdBefore);
 
 	void deleteAll();

--- a/src/main/java/com/reservation/tablereservationservice/domain/reservation/ReservationRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/domain/reservation/ReservationRepository.java
@@ -2,16 +2,18 @@ package com.reservation.tablereservationservice.domain.reservation;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import java.util.Optional;
 
 public interface ReservationRepository {
 
 	Reservation save(Reservation reservation);
 
 	Optional<Reservation> findByIdempotencyKey(String idempotencyKey);
+
+	Reservation fetchByIdempotencyKey(String idempotencyKey);
 
 	boolean existsByUserIdAndVisitAtAndStatusIn(Long userId, LocalDateTime visitAt, List<ReservationStatus> statuses);
 
@@ -36,6 +38,8 @@ public interface ReservationRepository {
 	Reservation fetchById(Long reservationId);
 
 	void updateStatus(Reservation reservation);
+
+	List<Reservation> findPendingBefore(LocalDateTime createdBefore);
 
 	void deleteAll();
 }

--- a/src/main/java/com/reservation/tablereservationservice/global/annotation/Idempotent.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/annotation/Idempotent.java
@@ -1,0 +1,11 @@
+package com.reservation.tablereservationservice.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Idempotent {
+}

--- a/src/main/java/com/reservation/tablereservationservice/global/config/PaymentQueueProperties.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/config/PaymentQueueProperties.java
@@ -1,0 +1,20 @@
+package com.reservation.tablereservationservice.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "rabbitmq.payment")
+public class PaymentQueueProperties {
+
+	private String exchange;
+	private String queue;
+	private String routingKey;
+	private String dlx;
+	private String dlq;
+}

--- a/src/main/java/com/reservation/tablereservationservice/global/config/RabbitMQConfig.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/config/RabbitMQConfig.java
@@ -1,0 +1,66 @@
+package com.reservation.tablereservationservice.global.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class RabbitMQConfig {
+
+	private final PaymentQueueProperties props;
+
+	@Bean
+	public DirectExchange paymentExchange() {
+		return new DirectExchange(props.getExchange());
+	}
+
+	@Bean
+	public DirectExchange paymentDlx() {
+		return new DirectExchange(props.getDlx());
+	}
+
+	@Bean
+	public Queue paymentQueue() {
+		return QueueBuilder.durable(props.getQueue())
+				.withArgument("x-dead-letter-exchange", props.getDlx())
+				.withArgument("x-dead-letter-routing-key", props.getDlq())
+				.build();
+	}
+
+	@Bean
+	public Queue paymentDlq() {
+		return QueueBuilder.durable(props.getDlq()).build();
+	}
+
+	@Bean
+	public Binding paymentBinding() {
+		return BindingBuilder.bind(paymentQueue()).to(paymentExchange()).with(props.getRoutingKey());
+	}
+
+	@Bean
+	public Binding paymentDlqBinding() {
+		return BindingBuilder.bind(paymentDlq()).to(paymentDlx()).with(props.getDlq());
+	}
+
+	@Bean
+	public Jackson2JsonMessageConverter messageConverter() {
+		return new Jackson2JsonMessageConverter();
+	}
+
+	@Bean
+	public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+		RabbitTemplate template = new RabbitTemplate(connectionFactory);
+		template.setMessageConverter(messageConverter());
+		return template;
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/global/config/ReservationStreamProperties.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/config/ReservationStreamProperties.java
@@ -13,14 +13,9 @@ import lombok.Setter;
 public class ReservationStreamProperties {
 
 	private String remainingKeyPrefix;
-	private String pendingKeyPrefix;
-	private int pendingKeyTtlSeconds;
+	private int pendingExpireThresholdSeconds;
 
 	public String remainingKey(Long slotId, String date) {
 		return remainingKeyPrefix + slotId + ":" + date;
-	}
-
-	public String pendingKey(Long userId, Long slotId, String date) {
-		return pendingKeyPrefix + userId + ":" + slotId + ":" + date;
 	}
 }

--- a/src/main/java/com/reservation/tablereservationservice/global/config/TossPaymentConfig.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/config/TossPaymentConfig.java
@@ -1,0 +1,39 @@
+package com.reservation.tablereservationservice.global.config;
+
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class TossPaymentConfig {
+
+	private final TossPaymentProperties properties;
+
+	@Bean
+	public RestClient tossRestClient() {
+		String encoded = Base64.getEncoder()
+				.encodeToString((properties.getSecretKey() + ":").getBytes(StandardCharsets.UTF_8));
+
+		HttpClient httpClient = HttpClient.newBuilder()
+				.connectTimeout(Duration.ofSeconds(properties.getConnectTimeoutSeconds()))
+				.build();
+
+		JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
+		factory.setReadTimeout(Duration.ofSeconds(properties.getReadTimeoutSeconds()));
+
+		return RestClient.builder()
+				.requestFactory(factory)
+				.defaultHeader("Authorization", "Basic " + encoded)
+				.defaultHeader("Content-Type", "application/json")
+				.build();
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/global/config/TossPaymentProperties.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/config/TossPaymentProperties.java
@@ -1,0 +1,20 @@
+package com.reservation.tablereservationservice.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "toss.payments")
+public class TossPaymentProperties {
+
+	private String secretKey;
+	private String confirmUrl;
+	private String paymentBaseUrl;
+	private int connectTimeoutSeconds;
+	private int readTimeoutSeconds;
+}

--- a/src/main/java/com/reservation/tablereservationservice/global/exception/ErrorCode.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/exception/ErrorCode.java
@@ -40,9 +40,17 @@ public enum ErrorCode {
 	RESERVATION_NOT_AVAILABLE("다른 예약이 선점되었습니다.", HttpStatus.CONFLICT),
 	RESERVATION_CONCURRENCY_ERROR("현재 예약 요청이 많아 처리가 지연되고 있습니다. 잠시 후 다시 시도해주세요.", HttpStatus.CONFLICT),
 
+	// 결제 오류
+	PAYMENT_AMOUNT_MISMATCH("결제 금액이 예약금과 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+	PAYMENT_RESERVATION_FAILED("이미 만료된 예약입니다.", HttpStatus.BAD_REQUEST),
+
+	// 503 Service Unavailable
+	TOSS_API_UNAVAILABLE("결제 서비스에 일시적인 문제가 발생했습니다. 잠시 후 다시 시도해주세요.", HttpStatus.SERVICE_UNAVAILABLE),
+
 	// 500 Internal Server Error
 	INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
 	private final String message;
 	private final HttpStatus status;
+
 	}

--- a/src/main/java/com/reservation/tablereservationservice/global/exception/ErrorCode.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/exception/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode {
 	// 결제 오류
 	PAYMENT_AMOUNT_MISMATCH("결제 금액이 예약금과 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
 	PAYMENT_RESERVATION_FAILED("이미 만료된 예약입니다.", HttpStatus.BAD_REQUEST),
+	PAYMENT_FAILED("결제에 실패했습니다.", HttpStatus.BAD_REQUEST),
 
 	// 503 Service Unavailable
 	TOSS_API_UNAVAILABLE("결제 서비스에 일시적인 문제가 발생했습니다. 잠시 후 다시 시도해주세요.", HttpStatus.SERVICE_UNAVAILABLE),

--- a/src/main/java/com/reservation/tablereservationservice/global/exception/PaymentException.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/exception/PaymentException.java
@@ -1,0 +1,8 @@
+package com.reservation.tablereservationservice.global.exception;
+
+public class PaymentException extends BusinessException {
+
+	public PaymentException(ErrorCode errorCode, Object... args) {
+		super(errorCode, args);
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/client/TossErrorResponse.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/client/TossErrorResponse.java
@@ -1,0 +1,14 @@
+package com.reservation.tablereservationservice.infrastructure.payment.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+class TossErrorResponse {
+
+	private String code;
+	private String message;
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/client/TossPaymentClient.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/client/TossPaymentClient.java
@@ -1,0 +1,68 @@
+package com.reservation.tablereservationservice.infrastructure.payment.client;
+
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import com.reservation.tablereservationservice.application.payment.PaymentClient;
+import com.reservation.tablereservationservice.application.payment.PaymentRequest;
+import com.reservation.tablereservationservice.application.payment.PaymentResult;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.PaymentException;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class TossPaymentClient implements PaymentClient {
+
+	@Value("${toss.payments.secret-key}")
+	private String secretKey;
+
+	@Value("${toss.payments.confirm-url}")
+	private String confirmUrl;
+
+	private RestClient restClient;
+
+	@PostConstruct
+	void init() {
+		String encoded = Base64.getEncoder()
+				.encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+
+		HttpClient httpClient = HttpClient.newBuilder()
+				.connectTimeout(Duration.ofSeconds(5))
+				.build();
+
+		restClient = RestClient.builder()
+				.requestFactory(new JdkClientHttpRequestFactory(httpClient))
+				.defaultHeader("Authorization", "Basic " + encoded)
+				.defaultHeader("Content-Type", "application/json")
+				.build();
+	}
+
+	@Override
+	@CircuitBreaker(name = "tossPayment", fallbackMethod = "fallback")
+	@Retry(name = "tossPayment")
+	public PaymentResult confirm(PaymentRequest request) {
+		return restClient
+				.post()
+				.uri(confirmUrl)
+				.body(request)
+				.retrieve()
+				.body(PaymentResult.class);
+	}
+
+	private PaymentResult fallback(PaymentRequest request, Exception e) {
+		log.error("[TOSS] 결제 승인 실패 orderId={}", request.getOrderId(), e);
+		throw new PaymentException(ErrorCode.TOSS_API_UNAVAILABLE);
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/client/TossPaymentClient.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/client/TossPaymentClient.java
@@ -1,68 +1,95 @@
 package com.reservation.tablereservationservice.infrastructure.payment.client;
 
-import java.net.http.HttpClient;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.util.Base64;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.reservation.tablereservationservice.application.payment.PaymentClient;
 import com.reservation.tablereservationservice.application.payment.PaymentRequest;
 import com.reservation.tablereservationservice.application.payment.PaymentResult;
+import com.reservation.tablereservationservice.global.config.TossPaymentProperties;
 import com.reservation.tablereservationservice.global.exception.ErrorCode;
 import com.reservation.tablereservationservice.global.exception.PaymentException;
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
-import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class TossPaymentClient implements PaymentClient {
 
-	@Value("${toss.payments.secret-key}")
-	private String secretKey;
+	private static final String ALREADY_PROCESSED = "ALREADY_PROCESSED_PAYMENT";
 
-	@Value("${toss.payments.confirm-url}")
-	private String confirmUrl;
+	private final TossPaymentProperties properties;
+	private final RestClient tossRestClient;
+	private final ObjectMapper objectMapper;
 
-	private RestClient restClient;
-
-	@PostConstruct
-	void init() {
-		String encoded = Base64.getEncoder()
-				.encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
-
-		HttpClient httpClient = HttpClient.newBuilder()
-				.connectTimeout(Duration.ofSeconds(5))
-				.build();
-
-		restClient = RestClient.builder()
-				.requestFactory(new JdkClientHttpRequestFactory(httpClient))
-				.defaultHeader("Authorization", "Basic " + encoded)
-				.defaultHeader("Content-Type", "application/json")
-				.build();
+	@Override
+	@CircuitBreaker(name = "tossPayment")
+	@Retry(name = "tossPayment")
+	public PaymentResult confirm(PaymentRequest request) {
+		try {
+			return tossRestClient
+					.post()
+					.uri(properties.getConfirmUrl())
+					.body(request)
+					.retrieve()
+					.body(PaymentResult.class);
+		} catch (HttpClientErrorException e) {
+			return handleClientError(request, e);
+		}
 	}
 
 	@Override
-	@CircuitBreaker(name = "tossPayment", fallbackMethod = "fallback")
-	@Retry(name = "tossPayment")
-	public PaymentResult confirm(PaymentRequest request) {
-		return restClient
-				.post()
-				.uri(confirmUrl)
-				.body(request)
-				.retrieve()
-				.body(PaymentResult.class);
+	public PaymentResult queryByPaymentKey(String paymentKey) {
+		PaymentResult result;
+		try {
+			result = tossRestClient
+					.get()
+					.uri(properties.getPaymentBaseUrl() + "/" + paymentKey)
+					.retrieve()
+					.body(PaymentResult.class);
+		} catch (Exception e) {
+			log.error("[TOSS] paymentKey 단건 조회 실패 paymentKey={}", paymentKey, e);
+			throw new PaymentException(ErrorCode.TOSS_API_UNAVAILABLE);
+		}
+
+		if (result == null) {
+			log.warn("[TOSS] paymentKey 단건 조회 응답 없음 paymentKey={}", paymentKey);
+			throw new PaymentException(ErrorCode.TOSS_API_UNAVAILABLE);
+		}
+
+		return result;
 	}
 
-	private PaymentResult fallback(PaymentRequest request, Exception e) {
-		log.error("[TOSS] 결제 승인 실패 orderId={}", request.getOrderId(), e);
-		throw new PaymentException(ErrorCode.TOSS_API_UNAVAILABLE);
+	private PaymentResult handleClientError(PaymentRequest request, HttpClientErrorException e) {
+		TossErrorResponse error = parseError(e);
+
+		if (ALREADY_PROCESSED.equals(error.getCode())) {
+			log.warn("[TOSS] 이미 처리된 결제 — paymentKey로 단건 조회 paymentKey={}", request.getPaymentKey());
+			PaymentResult result = queryByPaymentKey(request.getPaymentKey());
+
+			if (!result.isDone()) {
+				log.warn("[TOSS] 단건 조회 결제 미완료 paymentKey={}", request.getPaymentKey());
+				throw new PaymentException(ErrorCode.PAYMENT_FAILED);
+			}
+			return result;
+		}
+
+		log.warn("[TOSS] 결제 승인 거절 orderId={} code={} message={}", request.getOrderId(), error.getCode(), error.getMessage());
+		throw new PaymentException(ErrorCode.PAYMENT_FAILED);
+	}
+
+	private TossErrorResponse parseError(HttpClientErrorException e) {
+		try {
+			return objectMapper.readValue(e.getResponseBodyAsString(), TossErrorResponse.class);
+		} catch (Exception parseEx) {
+			log.warn("[TOSS] 에러 응답 파싱 실패 status={}", e.getStatusCode(), parseEx);
+			return new TossErrorResponse("UNKNOWN", e.getMessage());
+		}
 	}
 }

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/entity/PaymentEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/entity/PaymentEntity.java
@@ -27,13 +27,13 @@ public class PaymentEntity extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long paymentId;
 
-	@Column(nullable = false)
+	@Column(unique = true, nullable = false)
 	private Long reservationId;
 
 	@Column(unique = true, nullable = false, length = 36)
 	private String idempotencyKey;
 
-	@Column(nullable = false)
+	@Column(nullable = false, length = 200)
 	private String paymentKey;
 
 	@Column(nullable = false)

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/entity/PaymentEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/entity/PaymentEntity.java
@@ -1,0 +1,65 @@
+package com.reservation.tablereservationservice.infrastructure.payment.entity;
+
+import java.time.LocalDateTime;
+
+import com.reservation.tablereservationservice.domain.payment.PaymentStatus;
+import com.reservation.tablereservationservice.infrastructure.common.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "payment")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class PaymentEntity extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long paymentId;
+
+	@Column(nullable = false)
+	private Long reservationId;
+
+	@Column(unique = true, nullable = false, length = 36)
+	private String idempotencyKey;
+
+	@Column(nullable = false)
+	private String paymentKey;
+
+	@Column(nullable = false)
+	private Integer amount;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 10)
+	private PaymentStatus status;
+
+	@Column(nullable = false)
+	private LocalDateTime approvedAt;
+
+	@Builder
+	public PaymentEntity(
+			Long reservationId,
+			String idempotencyKey,
+			String paymentKey,
+			Integer amount,
+			PaymentStatus status,
+			LocalDateTime approvedAt
+	) {
+		this.reservationId = reservationId;
+		this.idempotencyKey = idempotencyKey;
+		this.paymentKey = paymentKey;
+		this.amount = amount;
+		this.status = status;
+		this.approvedAt = approvedAt;
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/mapper/PaymentMapper.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/mapper/PaymentMapper.java
@@ -1,0 +1,18 @@
+package com.reservation.tablereservationservice.infrastructure.payment.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+import com.reservation.tablereservationservice.domain.payment.Payment;
+import com.reservation.tablereservationservice.global.config.MapstructConfig;
+import com.reservation.tablereservationservice.infrastructure.payment.entity.PaymentEntity;
+
+@Mapper(config = MapstructConfig.class)
+public interface PaymentMapper {
+
+	PaymentMapper INSTANCE = Mappers.getMapper(PaymentMapper.class);
+
+	Payment toDomain(PaymentEntity entity);
+
+	PaymentEntity toEntity(Payment payment);
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/messaging/PaymentQueueListener.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/messaging/PaymentQueueListener.java
@@ -1,0 +1,32 @@
+package com.reservation.tablereservationservice.infrastructure.payment.messaging;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+import com.reservation.tablereservationservice.application.payment.service.PaymentConfirmationService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentQueueListener {
+
+	private final PaymentConfirmationService paymentConfirmationService;
+
+	@RabbitListener(queues = "${rabbitmq.payment.queue}")
+	public void handlePaymentConfirm(PaymentQueueMessage message) {
+		try {
+			paymentConfirmationService.confirm(message);
+			log.info("[PAYMENT_LISTENER] 결제 확정 완료 reservationId={}", message.getReservationId());
+		} catch (DataIntegrityViolationException e) {
+			// idempotency_key UNIQUE 제약 위반 — 동일 메시지 중복 수신. ack 처리
+			log.warn("[PAYMENT_LISTENER] 중복 결제 메시지 감지 — ack 처리. idempotencyKey={}", message.getIdempotencyKey());
+		} catch (Exception e) {
+			log.error("[PAYMENT_LISTENER] 결제 확정 실패 reservationId={}", message.getReservationId(), e);
+			throw e;
+		}
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/messaging/PaymentQueueMessage.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/messaging/PaymentQueueMessage.java
@@ -1,0 +1,32 @@
+package com.reservation.tablereservationservice.infrastructure.payment.messaging;
+
+import java.time.LocalDateTime;
+
+import com.reservation.tablereservationservice.application.payment.PaymentResult;
+import com.reservation.tablereservationservice.domain.reservation.Reservation;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PaymentQueueMessage {
+
+	private Long reservationId;
+	private String idempotencyKey;
+	private String paymentKey;
+	private Integer amount;
+	private LocalDateTime approvedAt;
+
+	public static PaymentQueueMessage of(Reservation reservation, String orderId, PaymentResult result) {
+		PaymentQueueMessage message = new PaymentQueueMessage();
+		message.reservationId = reservation.getReservationId();
+		message.idempotencyKey = orderId;
+		message.paymentKey = result.getPaymentKey();
+		message.amount = result.getTotalAmount();
+		message.approvedAt = result.getApprovedAt().toLocalDateTime();
+		return message;
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/messaging/PaymentQueueMessage.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/messaging/PaymentQueueMessage.java
@@ -20,7 +20,7 @@ public class PaymentQueueMessage {
 	private Integer amount;
 	private LocalDateTime approvedAt;
 
-	public static PaymentQueueMessage of(Reservation reservation, String orderId, PaymentResult result) {
+	public static PaymentQueueMessage ofConfirmed(Reservation reservation, String orderId, PaymentResult result) {
 		PaymentQueueMessage message = new PaymentQueueMessage();
 		message.reservationId = reservation.getReservationId();
 		message.idempotencyKey = orderId;

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/messaging/PaymentQueuePublisher.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/messaging/PaymentQueuePublisher.java
@@ -1,0 +1,27 @@
+package com.reservation.tablereservationservice.infrastructure.payment.messaging;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+import com.reservation.tablereservationservice.global.config.PaymentQueueProperties;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentQueuePublisher {
+
+	private final RabbitTemplate rabbitTemplate;
+	private final PaymentQueueProperties paymentQueueProperties;
+
+	public void publish(PaymentQueueMessage message) {
+		rabbitTemplate.convertAndSend(
+				paymentQueueProperties.getExchange(),
+				paymentQueueProperties.getRoutingKey(),
+				message
+		);
+		log.info("[PAYMENT_QUEUE] 결제 확정 메시지 발행 reservationId={}", message.getReservationId());
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/repository/JpaPaymentRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/repository/JpaPaymentRepository.java
@@ -1,0 +1,23 @@
+package com.reservation.tablereservationservice.infrastructure.payment.repository;
+
+import org.springframework.stereotype.Repository;
+
+import com.reservation.tablereservationservice.domain.payment.Payment;
+import com.reservation.tablereservationservice.domain.payment.PaymentRepository;
+import com.reservation.tablereservationservice.infrastructure.payment.entity.PaymentEntity;
+import com.reservation.tablereservationservice.infrastructure.payment.mapper.PaymentMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class JpaPaymentRepository implements PaymentRepository {
+
+	private final PaymentEntityRepository paymentEntityRepository;
+
+	@Override
+	public Payment save(Payment payment) {
+		PaymentEntity saved = paymentEntityRepository.save(PaymentMapper.INSTANCE.toEntity(payment));
+		return PaymentMapper.INSTANCE.toDomain(saved);
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/repository/PaymentEntityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/payment/repository/PaymentEntityRepository.java
@@ -1,0 +1,8 @@
+package com.reservation.tablereservationservice.infrastructure.payment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.reservation.tablereservationservice.infrastructure.payment.entity.PaymentEntity;
+
+public interface PaymentEntityRepository extends JpaRepository<PaymentEntity, Long> {
+}

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/redis/RedisRemainingCapacityInitializer.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/redis/RedisRemainingCapacityInitializer.java
@@ -1,4 +1,4 @@
-package com.reservation.tablereservationservice.infrastructure.stream;
+package com.reservation.tablereservationservice.infrastructure.redis;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -19,7 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-@Order(1) // Consumer 구독(Order=2) 보다 먼저 실행되어야 한다.
+@Order(1) // Consumer 구독(Order=2) 보다 먼저 실행
 public class RedisRemainingCapacityInitializer implements ApplicationRunner {
 
 	private final DailySlotCapacityRepository dailySlotCapacityRepository;

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/redis/ReservationPublisher.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/redis/ReservationPublisher.java
@@ -1,4 +1,4 @@
-package com.reservation.tablereservationservice.infrastructure.stream;
+package com.reservation.tablereservationservice.infrastructure.redis;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/ReservationEntity.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/entity/ReservationEntity.java
@@ -50,12 +50,17 @@ public class ReservationEntity extends BaseTimeEntity {
 	@Column(unique = true, length = 36)
 	private String idempotencyKey;
 
+	@Column(length = 200)
+	private String paymentKey;
+
 	@Version
 	private Long version;
 
 	@Builder
-	public ReservationEntity(Long userId, Long slotId, LocalDateTime visitAt, Integer partySize,
-		String note, ReservationStatus status, String idempotencyKey) {
+	public ReservationEntity(
+			Long userId, Long slotId, LocalDateTime visitAt, Integer partySize,
+			String note, ReservationStatus status, String idempotencyKey, String paymentKey
+	) {
 		this.userId = userId;
 		this.slotId = slotId;
 		this.visitAt = visitAt;
@@ -63,9 +68,14 @@ public class ReservationEntity extends BaseTimeEntity {
 		this.note = note;
 		this.status = status;
 		this.idempotencyKey = idempotencyKey;
+		this.paymentKey = paymentKey;
 	}
 
 	public void updateStatus(ReservationStatus status) {
-	    this.status = status;
+		this.status = status;
+	}
+
+	public void updatePaymentKey(String paymentKey) {
+		this.paymentKey = paymentKey;
 	}
 }

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaReservationRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaReservationRepository.java
@@ -39,6 +39,12 @@ public class JpaReservationRepository implements ReservationRepository {
 	}
 
 	@Override
+	public Reservation fetchByIdempotencyKey(String idempotencyKey) {
+		return findByIdempotencyKey(idempotencyKey)
+				.orElseThrow(() -> new ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "Reservation"));
+	}
+
+	@Override
 	public boolean existsByUserIdAndVisitAtAndStatusIn(Long userId, LocalDateTime visitAt, List<ReservationStatus> statuses) {
 		return reservationEntityRepository.existsByUserIdAndVisitAtAndStatusIn(userId, visitAt, statuses);
 	}
@@ -89,6 +95,14 @@ public class JpaReservationRepository implements ReservationRepository {
 
 		entity.updateStatus(reservation.getStatus());
 		// save() 호출 없음 -> 변경 감지 UPDATE
+	}
+
+	@Override
+	public List<Reservation> findPendingBefore(LocalDateTime createdBefore) {
+		return reservationEntityRepository.findPendingBefore(createdBefore)
+				.stream()
+				.map(ReservationMapper.INSTANCE::toDomain)
+				.toList();
 	}
 
 	@Override

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaReservationRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/JpaReservationRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.reservation.tablereservationservice.domain.reservation.Reservation;
 import com.reservation.tablereservationservice.domain.reservation.ReservationRepository;
@@ -89,12 +90,19 @@ public class JpaReservationRepository implements ReservationRepository {
 	}
 
 	@Override
+	@Transactional
 	public void updateStatus(Reservation reservation) {
 		ReservationEntity entity = reservationEntityRepository.findById(reservation.getReservationId())
 				.orElseThrow(() -> new ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "Reservation"));
-
 		entity.updateStatus(reservation.getStatus());
-		// save() 호출 없음 -> 변경 감지 UPDATE
+	}
+
+	@Override
+	@Transactional
+	public void updatePaymentKey(Reservation reservation) {
+		ReservationEntity entity = reservationEntityRepository.findById(reservation.getReservationId())
+				.orElseThrow(() -> new ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "Reservation"));
+		entity.updatePaymentKey(reservation.getPaymentKey());
 	}
 
 	@Override

--- a/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/ReservationEntityRepository.java
+++ b/src/main/java/com/reservation/tablereservationservice/infrastructure/reservation/repository/ReservationEntityRepository.java
@@ -1,9 +1,8 @@
 package com.reservation.tablereservationservice.infrastructure.reservation.repository;
 
 import java.time.LocalDateTime;
-import java.util.List;
-
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -52,4 +51,7 @@ public interface ReservationEntityRepository extends JpaRepository<ReservationEn
 		@Param("to") LocalDateTime to,
 		Pageable pageable
 	);
+
+	@Query("select r from ReservationEntity r where r.status = 'PENDING' and r.createdAt < :createdBefore")
+	List<ReservationEntity> findPendingBefore(@Param("createdBefore") LocalDateTime createdBefore);
 }

--- a/src/main/java/com/reservation/tablereservationservice/presentation/payment/controller/PaymentController.java
+++ b/src/main/java/com/reservation/tablereservationservice/presentation/payment/controller/PaymentController.java
@@ -23,7 +23,7 @@ public class PaymentController {
 	private final PaymentService paymentService;
 
 	@CustomerOnly
-	@PostMapping("/approve")
+	@PostMapping("/confirm")
 	public ApiResponse<Void> confirm(@Valid @RequestBody PaymentConfirmRequestDto requestDto, @LoginUser CurrentUser user) {
 		paymentService.approve(user.userId(), requestDto);
 		return ApiResponse.success("예약 확정 중입니다.");

--- a/src/main/java/com/reservation/tablereservationservice/presentation/payment/controller/PaymentController.java
+++ b/src/main/java/com/reservation/tablereservationservice/presentation/payment/controller/PaymentController.java
@@ -1,0 +1,31 @@
+package com.reservation.tablereservationservice.presentation.payment.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.reservation.tablereservationservice.application.payment.service.PaymentService;
+import com.reservation.tablereservationservice.global.annotation.CustomerOnly;
+import com.reservation.tablereservationservice.global.annotation.LoginUser;
+import com.reservation.tablereservationservice.global.common.CurrentUser;
+import com.reservation.tablereservationservice.presentation.common.ApiResponse;
+import com.reservation.tablereservationservice.presentation.payment.dto.PaymentConfirmRequestDto;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/payments")
+public class PaymentController {
+
+	private final PaymentService paymentService;
+
+	@CustomerOnly
+	@PostMapping("/confirm")
+	public ApiResponse<Void> confirm(@Valid @RequestBody PaymentConfirmRequestDto requestDto, @LoginUser CurrentUser user) {
+		paymentService.confirmPayment(user.userId(), requestDto);
+		return ApiResponse.success("예약 확정 중입니다.");
+	}
+}

--- a/src/main/java/com/reservation/tablereservationservice/presentation/payment/controller/PaymentController.java
+++ b/src/main/java/com/reservation/tablereservationservice/presentation/payment/controller/PaymentController.java
@@ -23,9 +23,9 @@ public class PaymentController {
 	private final PaymentService paymentService;
 
 	@CustomerOnly
-	@PostMapping("/confirm")
+	@PostMapping("/approve")
 	public ApiResponse<Void> confirm(@Valid @RequestBody PaymentConfirmRequestDto requestDto, @LoginUser CurrentUser user) {
-		paymentService.confirmPayment(user.userId(), requestDto);
+		paymentService.approve(user.userId(), requestDto);
 		return ApiResponse.success("예약 확정 중입니다.");
 	}
 }

--- a/src/main/java/com/reservation/tablereservationservice/presentation/payment/dto/PaymentConfirmRequestDto.java
+++ b/src/main/java/com/reservation/tablereservationservice/presentation/payment/dto/PaymentConfirmRequestDto.java
@@ -1,0 +1,24 @@
+package com.reservation.tablereservationservice.presentation.payment.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentConfirmRequestDto {
+
+	@NotBlank(message = "paymentKey는 필수입니다.")
+	private String paymentKey;
+
+	@NotBlank(message = "orderId는 필수입니다.")
+	private String orderId;
+
+	@NotNull(message = "결제 금액은 필수입니다.")
+	@Min(value = 1, message = "결제 금액은 1원 이상이어야 합니다.")
+	private Integer amount;
+}

--- a/src/main/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationController.java
+++ b/src/main/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.reservation.tablereservationservice.application.reservation.facade.ReservationFacade;
 import com.reservation.tablereservationservice.application.reservation.facade.ReservationOptimisticFacade;
 import com.reservation.tablereservationservice.application.reservation.service.ReservationCreateResult;
 import com.reservation.tablereservationservice.application.reservation.service.ReservationService;
@@ -38,29 +39,30 @@ import lombok.RequiredArgsConstructor;
 public class ReservationController {
 
 	private final ReservationService reservationService;
+	private final ReservationFacade reservationFacade;
 	private final ReservationOptimisticFacade reservationOptimisticFacade;
 
 	@CustomerOnly
 	@PostMapping
 	public ApiResponse<ReservationResponseDto> create(
-		@Valid @RequestBody ReservationRequestDto requestDto,
-		@RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
-		@LoginUser CurrentUser user
+			@Valid @RequestBody ReservationRequestDto requestDto,
+			@RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
+			@LoginUser CurrentUser user
 	) {
 		if (idempotencyKey == null || idempotencyKey.isBlank()) {
 			throw new ReservationException(ErrorCode.MISSING_PARAMETER);
 		}
 
-		ReservationCreateResult result = reservationService.reserve(user.email(), requestDto, idempotencyKey);
+		ReservationCreateResult result = reservationFacade.reserve(user.email(), requestDto, idempotencyKey);
 		return ApiResponse.success("예약 접수 성공", ReservationResponseDto.from(result));
 	}
 
 	@CustomerOnly
 	@GetMapping("/me")
 	public ApiResponse<PageResponseDto<ReservationListResponseDto>> findMyReservations(
-		@ModelAttribute ReservationSearchDto searchDto,
-		@PageableDefault(page = 0, size = 10, sort = "visitAt", direction = Sort.Direction.DESC) Pageable pageable,
-		@LoginUser CurrentUser user
+			@ModelAttribute ReservationSearchDto searchDto,
+			@PageableDefault(page = 0, size = 10, sort = "visitAt", direction = Sort.Direction.DESC) Pageable pageable,
+			@LoginUser CurrentUser user
 	) {
 		searchDto.setPageable(pageable);
 		PageResponseDto<ReservationListResponseDto> responseDto = reservationService.findMyReservations(user.email(), searchDto);
@@ -70,9 +72,9 @@ public class ReservationController {
 	@OwnerOnly
 	@GetMapping("/owner")
 	public ApiResponse<PageResponseDto<ReservationListResponseDto>> findOwnerReservations(
-		@ModelAttribute ReservationSearchDto searchDto,
-		@PageableDefault(page = 0, size = 10, sort = "visitAt", direction = Sort.Direction.DESC) Pageable pageable,
-		@LoginUser CurrentUser user
+			@ModelAttribute ReservationSearchDto searchDto,
+			@PageableDefault(page = 0, size = 10, sort = "visitAt", direction = Sort.Direction.DESC) Pageable pageable,
+			@LoginUser CurrentUser user
 	) {
 		searchDto.setPageable(pageable);
 		PageResponseDto<ReservationListResponseDto> responseDto = reservationService.findOwnerReservations(user.email(), searchDto);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,15 @@ spring:
 server:
   port: 8080
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  endpoint:
+    prometheus:
+      enabled: true
+
 redis:
   reservation:
     remaining-key-prefix: "reservation:remaining:"
@@ -14,3 +23,33 @@ redis:
     pending-key-ttl-seconds: 900  # 15분 (스케줄러 만료 임계 10분 + 주기 5분 이상)
   pubsub:
     notification-channel: notification:events
+
+rabbitmq:
+  payment:
+    exchange: payment-exchange
+    queue: payment-queue
+    routing-key: payment.confirm
+    dlx: payment-dlx
+    dlq: payment-dlq
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      tossPayment:
+        sliding-window-size: 10
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 10s
+        permitted-number-of-calls-in-half-open-state: 3
+        ignore-exceptions:
+          - org.springframework.web.client.HttpClientErrorException  # 4xx는 CB 실패로 집계 안 함
+  retry:
+    instances:
+      tossPayment:
+        max-attempts: 3
+        wait-duration: 1s
+        retry-exceptions:
+          - java.io.IOException                                      # 네트워크 단절
+          - org.springframework.web.client.ResourceAccessException   # 연결 타임아웃
+          - org.springframework.web.client.HttpServerErrorException  # Toss 5xx
+        ignore-exceptions:
+          - org.springframework.web.client.HttpClientErrorException  # 4xx 재시도 금지

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,8 +19,8 @@ management:
 redis:
   reservation:
     remaining-key-prefix: "reservation:remaining:"
-    pending-key-prefix: "reservation:temporary:"
-    pending-key-ttl-seconds: 900  # 15분 (스케줄러 만료 임계 10분 + 주기 5분 이상)
+    pending-expire-threshold-seconds: 600  # Toss 결제 승인 만료(10분)와 동기화
+    pending-expire-scheduler-seconds: 60   # 스케줄러 실행 주기: 1분마다 체크
   pubsub:
     notification-channel: notification:events
 
@@ -34,22 +34,25 @@ rabbitmq:
 
 resilience4j:
   circuitbreaker:
+    circuit-breaker-aspect-order: 1  # CB가 outer, Retry가 inner — 재시도 소진 후 CB가 결과 집계
     instances:
       tossPayment:
-        sliding-window-size: 10
-        failure-rate-threshold: 50
-        wait-duration-in-open-state: 10s
-        permitted-number-of-calls-in-half-open-state: 3
+        sliding-window-size: 10                                      # 최근 10번 호출 기준으로 판단
+        failure-rate-threshold: 50                                   # 실패율 50% 초과 시 OPEN
+        wait-duration-in-open-state: 10s                             # OPEN 후 10초 대기 후 HALF_OPEN
+        permitted-number-of-calls-in-half-open-state: 3              # HALF_OPEN에서 3번 테스트
         ignore-exceptions:
-          - org.springframework.web.client.HttpClientErrorException  # 4xx는 CB 실패로 집계 안 함
+          - org.springframework.web.client.HttpClientErrorException         # 4xx: CB 실패 집계 제외
+          - com.reservation.tablereservationservice.global.exception.PaymentException  # 유저 과실(카드거절 등): CB 실패 집계 제외
   retry:
+    retry-aspect-order: 2
     instances:
       tossPayment:
         max-attempts: 3
         wait-duration: 1s
         retry-exceptions:
-          - java.io.IOException                                      # 네트워크 단절
-          - org.springframework.web.client.ResourceAccessException   # 연결 타임아웃
-          - org.springframework.web.client.HttpServerErrorException  # Toss 5xx
+          - java.io.IOException                                             # 네트워크 단절
+          - org.springframework.web.client.ResourceAccessException          # 연결 타임아웃
+          - org.springframework.web.client.HttpServerErrorException         # Toss 5xx
         ignore-exceptions:
-          - org.springframework.web.client.HttpClientErrorException  # 4xx 재시도 금지
+          - org.springframework.web.client.HttpClientErrorException         # 4xx 재시도 금지

--- a/src/test/java/com/reservation/tablereservationservice/application/payment/service/PaymentConfirmationServiceTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/payment/service/PaymentConfirmationServiceTest.java
@@ -1,0 +1,183 @@
+package com.reservation.tablereservationservice.application.payment.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.reservation.tablereservationservice.application.notification.NotificationService;
+import com.reservation.tablereservationservice.application.payment.PaymentResult;
+import com.reservation.tablereservationservice.domain.payment.Payment;
+import com.reservation.tablereservationservice.domain.payment.PaymentRepository;
+import com.reservation.tablereservationservice.domain.payment.PaymentStatus;
+import com.reservation.tablereservationservice.domain.reservation.Reservation;
+import com.reservation.tablereservationservice.domain.reservation.ReservationRepository;
+import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
+import com.reservation.tablereservationservice.domain.restaurant.Restaurant;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantRepository;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlot;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlotRepository;
+import com.reservation.tablereservationservice.fixture.ReservationFixture;
+import com.reservation.tablereservationservice.fixture.RestaurantFixture;
+import com.reservation.tablereservationservice.fixture.RestaurantSlotFixture;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.ReservationException;
+import com.reservation.tablereservationservice.global.transaction.TransactionHandler;
+import com.reservation.tablereservationservice.infrastructure.payment.messaging.PaymentQueueMessage;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentConfirmationServiceTest {
+
+	private static final Long RESERVATION_ID = 100L;
+	private static final Long SLOT_ID = 10L;
+	private static final Long RESTAURANT_ID = 200L;
+	private static final Long OWNER_ID = 2L;
+	private static final String IDEMPOTENCY_KEY = "order-uuid-1234";
+	private static final String PAYMENT_KEY = "toss-payment-key";
+	private static final int AMOUNT = 10000;
+	private static final OffsetDateTime APPROVED_AT = OffsetDateTime.of(2030, 1, 1, 19, 0, 0, 0, ZoneOffset.UTC);
+
+	@Mock
+	private ReservationRepository reservationRepository;
+
+	@Mock
+	private PaymentRepository paymentRepository;
+
+	@Mock
+	private RestaurantSlotRepository restaurantSlotRepository;
+
+	@Mock
+	private RestaurantRepository restaurantRepository;
+
+	@Mock
+	private NotificationService notificationService;
+
+	@Mock
+	private TransactionHandler transactionHandler;
+
+	@InjectMocks
+	private PaymentConfirmationService paymentConfirmationService;
+
+	private Reservation pendingReservation;
+	private RestaurantSlot slot;
+	private Restaurant restaurant;
+	private PaymentQueueMessage queueMessage;
+
+	@BeforeEach
+	void setUp() {
+		pendingReservation = ReservationFixture.pending()
+				.reservationId(RESERVATION_ID)
+				.userId(1L)
+				.slotId(SLOT_ID)
+				.partySize(2)
+				.idempotencyKey(IDEMPOTENCY_KEY)
+				.build();
+
+		slot = RestaurantSlotFixture.slot()
+				.slotId(SLOT_ID)
+				.restaurantId(RESTAURANT_ID)
+				.build();
+
+		restaurant = RestaurantFixture.restaurant()
+				.restaurantId(RESTAURANT_ID)
+				.ownerId(OWNER_ID)
+				.name("강남 한상")
+				.build();
+
+		PaymentResult result = new PaymentResult(PAYMENT_KEY, IDEMPOTENCY_KEY, AMOUNT, APPROVED_AT, "DONE");
+		queueMessage = PaymentQueueMessage.ofConfirmed(pendingReservation, IDEMPOTENCY_KEY, result);
+	}
+
+	@Test
+	@DisplayName("결제 확정 성공 - 예약 상태가 CONFIRMED로 변경되고 Payment가 저장된다")
+	void confirm_success() {
+		// given
+		given(reservationRepository.fetchById(RESERVATION_ID)).willReturn(pendingReservation);
+		given(restaurantSlotRepository.fetchById(SLOT_ID)).willReturn(slot);
+		given(restaurantRepository.findById(RESTAURANT_ID)).willReturn(Optional.of(restaurant));
+		given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+
+		// when
+		paymentConfirmationService.confirm(queueMessage);
+
+		// then - 예약 상태
+		assertThat(pendingReservation.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+		verify(reservationRepository).updateStatus(pendingReservation);
+
+		// then - 결제 레코드
+		ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
+		verify(paymentRepository).save(paymentCaptor.capture());
+		Payment saved = paymentCaptor.getValue();
+		assertThat(saved.getReservationId()).isEqualTo(RESERVATION_ID);
+		assertThat(saved.getIdempotencyKey()).isEqualTo(IDEMPOTENCY_KEY);
+		assertThat(saved.getPaymentKey()).isEqualTo(PAYMENT_KEY);
+		assertThat(saved.getAmount()).isEqualTo(AMOUNT);
+		assertThat(saved.getStatus()).isEqualTo(PaymentStatus.DONE);
+		assertThat(saved.getApprovedAt()).isEqualTo(queueMessage.getApprovedAt());
+
+		// then - 알림 예약
+		verify(transactionHandler).runAfterCommit(any());
+	}
+
+	@Test
+	@DisplayName("결제 확정 실패 - 예약을 찾을 수 없으면 예외가 발생한다")
+	void confirm_fail_reservationNotFound() {
+		// given
+		given(reservationRepository.fetchById(RESERVATION_ID))
+				.willThrow(new ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "예약"));
+
+		// when & then
+		assertThatThrownBy(() -> paymentConfirmationService.confirm(queueMessage))
+				.isInstanceOf(ReservationException.class)
+				.satisfies(ex -> assertThat(((ReservationException) ex).getErrorCode())
+						.isEqualTo(ErrorCode.RESOURCE_NOT_FOUND));
+
+		verifyNoInteractions(paymentRepository, notificationService);
+	}
+
+	@Test
+	@DisplayName("레이스 컨디션 - PAYMENT_FAILED 예약은 조용히 종료한다 (ack)")
+	void confirm_raceCondition_paymentFailed_silentlyReturns() {
+		// given — 스케줄러가 먼저 PAYMENT_FAILED로 바꾼 상황
+		Reservation failedReservation = ReservationFixture.paymentFailed()
+				.reservationId(RESERVATION_ID)
+				.slotId(SLOT_ID)
+				.idempotencyKey(IDEMPOTENCY_KEY)
+				.build();
+
+		given(reservationRepository.fetchById(RESERVATION_ID)).willReturn(failedReservation);
+
+		// when & then
+		assertThatCode(() -> paymentConfirmationService.confirm(queueMessage)).doesNotThrowAnyException();
+		verifyNoInteractions(paymentRepository, notificationService);
+	}
+
+	@Test
+	@DisplayName("레이스 컨디션 - CONFIRMED 예약은 조용히 종료한다 (ack)")
+	void confirm_raceCondition_alreadyConfirmed_silentlyReturns() {
+		// given — 이미 다른 컨슈머가 처리 완료한 상황
+		Reservation confirmedReservation = ReservationFixture.confirmed()
+				.reservationId(RESERVATION_ID)
+				.slotId(SLOT_ID)
+				.idempotencyKey(IDEMPOTENCY_KEY)
+				.build();
+
+		given(reservationRepository.fetchById(RESERVATION_ID)).willReturn(confirmedReservation);
+
+		// when & then
+		assertThatCode(() -> paymentConfirmationService.confirm(queueMessage)).doesNotThrowAnyException();
+		verifyNoInteractions(paymentRepository, notificationService);
+	}
+}

--- a/src/test/java/com/reservation/tablereservationservice/application/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/payment/service/PaymentServiceTest.java
@@ -1,0 +1,228 @@
+package com.reservation.tablereservationservice.application.payment.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.web.client.HttpServerErrorException;
+
+import com.reservation.tablereservationservice.application.payment.PaymentClient;
+import com.reservation.tablereservationservice.application.payment.PaymentRequest;
+import com.reservation.tablereservationservice.application.payment.PaymentResult;
+
+import com.reservation.tablereservationservice.domain.reservation.Reservation;
+import com.reservation.tablereservationservice.domain.reservation.ReservationRepository;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlot;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlotRepository;
+import com.reservation.tablereservationservice.fixture.ReservationFixture;
+import com.reservation.tablereservationservice.fixture.RestaurantSlotFixture;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.PaymentException;
+import com.reservation.tablereservationservice.infrastructure.payment.messaging.PaymentQueueMessage;
+import com.reservation.tablereservationservice.infrastructure.payment.messaging.PaymentQueuePublisher;
+import com.reservation.tablereservationservice.presentation.payment.dto.PaymentConfirmRequestDto;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+
+	private static final Long USER_ID = 1L;
+	private static final Long SLOT_ID = 10L;
+	private static final Long RESERVATION_ID = 100L;
+	private static final String IDEMPOTENCY_KEY = "order-uuid-1234";
+	private static final String PAYMENT_KEY = "toss-payment-key";
+	private static final int DEPOSIT_PER_PERSON = 5000;
+	private static final int PARTY_SIZE = 2;
+	private static final int EXPECTED_AMOUNT = DEPOSIT_PER_PERSON * PARTY_SIZE; // 10000
+
+	@Mock
+	private ReservationRepository reservationRepository;
+
+	@Mock
+	private RestaurantSlotRepository restaurantSlotRepository;
+
+	@Mock
+	private PaymentClient paymentClient;
+
+	@Mock
+	private PaymentQueuePublisher paymentQueuePublisher;
+
+	@InjectMocks
+	private PaymentService paymentService;
+
+	private Reservation pendingReservation;
+	private RestaurantSlot slot;
+	private PaymentConfirmRequestDto requestDto;
+
+	@BeforeEach
+	void setUp() {
+		slot = RestaurantSlotFixture.slot()
+				.slotId(SLOT_ID)
+				.depositPerPerson(DEPOSIT_PER_PERSON)
+				.build();
+
+		pendingReservation = ReservationFixture.pending()
+				.reservationId(RESERVATION_ID)
+				.userId(USER_ID)
+				.slotId(SLOT_ID)
+				.partySize(PARTY_SIZE)
+				.idempotencyKey(IDEMPOTENCY_KEY)
+				.build();
+
+		requestDto = new PaymentConfirmRequestDto(PAYMENT_KEY, IDEMPOTENCY_KEY, EXPECTED_AMOUNT);
+	}
+
+	@Test
+	@DisplayName("결제 확정 성공 - 결제 승인 후 큐에 메시지를 발행한다")
+	void approve_success() {
+		// given
+		OffsetDateTime approvedAt = OffsetDateTime.of(2030, 1, 1, 19, 0, 0, 0, ZoneOffset.ofHours(9));
+		PaymentResult tossResult = new PaymentResult(PAYMENT_KEY, IDEMPOTENCY_KEY, EXPECTED_AMOUNT, approvedAt, "DONE");
+
+		given(reservationRepository.fetchByIdempotencyKey(IDEMPOTENCY_KEY)).willReturn(pendingReservation);
+		given(restaurantSlotRepository.fetchById(SLOT_ID)).willReturn(slot);
+		given(paymentClient.confirm(any(PaymentRequest.class))).willReturn(tossResult);
+
+		// when
+		paymentService.approve(USER_ID, requestDto);
+
+		// then
+		verify(reservationRepository).updatePaymentKey(pendingReservation);
+		ArgumentCaptor<PaymentQueueMessage> messageCaptor = ArgumentCaptor.forClass(PaymentQueueMessage.class);
+		verify(paymentQueuePublisher).publish(messageCaptor.capture());
+
+		PaymentQueueMessage published = messageCaptor.getValue();
+		assertThat(published.getReservationId()).isEqualTo(RESERVATION_ID);
+		assertThat(published.getIdempotencyKey()).isEqualTo(IDEMPOTENCY_KEY);
+		assertThat(published.getPaymentKey()).isEqualTo(PAYMENT_KEY);
+		assertThat(published.getAmount()).isEqualTo(EXPECTED_AMOUNT);
+		assertThat(published.getApprovedAt()).isEqualTo(approvedAt.toLocalDateTime());
+	}
+
+	@Test
+	@DisplayName("결제 확정 실패 - 예약을 찾을 수 없으면 예외가 발생한다")
+	void approve_fail_reservationNotFound() {
+		// given
+		given(reservationRepository.fetchByIdempotencyKey(IDEMPOTENCY_KEY))
+				.willThrow(new PaymentException(ErrorCode.RESOURCE_NOT_FOUND, "예약"));
+
+		// when & then
+		assertThatThrownBy(() -> paymentService.approve(USER_ID, requestDto))
+				.isInstanceOf(PaymentException.class)
+				.satisfies(ex -> assertThat(((PaymentException)ex).getErrorCode())
+						.isEqualTo(ErrorCode.RESOURCE_NOT_FOUND));
+
+		verifyNoInteractions(paymentClient, paymentQueuePublisher);
+	}
+
+	@Test
+	@DisplayName("결제 확정 실패 - 본인 예약이 아니면 접근 금지 예외가 발생한다")
+	void approve_fail_notOwner() {
+		// given
+		Reservation otherUserReservation = ReservationFixture.pending()
+				.reservationId(RESERVATION_ID)
+				.userId(999L)
+				.slotId(SLOT_ID)
+				.partySize(PARTY_SIZE)
+				.idempotencyKey(IDEMPOTENCY_KEY)
+				.build();
+
+		given(reservationRepository.fetchByIdempotencyKey(IDEMPOTENCY_KEY)).willReturn(otherUserReservation);
+
+		// when & then
+		assertThatThrownBy(() -> paymentService.approve(USER_ID, requestDto))
+				.isInstanceOf(PaymentException.class)
+				.satisfies(ex -> assertThat(((PaymentException)ex).getErrorCode())
+						.isEqualTo(ErrorCode.ACCESS_DENIED));
+
+		verifyNoInteractions(paymentClient, paymentQueuePublisher);
+	}
+
+	@Test
+	@DisplayName("결제 확정 성공 - 이미 CONFIRMED인 예약은 멱등 처리한다 (결제 승인 재호출 없음)")
+	void approve_alreadyConfirmed_idempotent() {
+		// given
+		Reservation confirmedReservation = ReservationFixture.confirmed()
+				.reservationId(RESERVATION_ID)
+				.userId(USER_ID)
+				.slotId(SLOT_ID)
+				.idempotencyKey(IDEMPOTENCY_KEY)
+				.build();
+
+		given(reservationRepository.fetchByIdempotencyKey(IDEMPOTENCY_KEY)).willReturn(confirmedReservation);
+
+		// when & then
+		assertThatCode(() -> paymentService.approve(USER_ID, requestDto)).doesNotThrowAnyException();
+		verifyNoInteractions(paymentClient, paymentQueuePublisher);
+	}
+
+	@Test
+	@DisplayName("결제 확정 실패 - PAYMENT_FAILED 예약은 예외가 발생한다")
+	void approvePayment_fail_Failed() {
+		// given
+		Reservation failedReservation = ReservationFixture.paymentFailed()
+				.reservationId(RESERVATION_ID)
+				.userId(USER_ID)
+				.slotId(SLOT_ID)
+				.idempotencyKey(IDEMPOTENCY_KEY)
+				.build();
+
+		given(reservationRepository.fetchByIdempotencyKey(IDEMPOTENCY_KEY)).willReturn(failedReservation);
+
+		// when & then
+		assertThatThrownBy(() -> paymentService.approve(USER_ID, requestDto))
+				.isInstanceOf(PaymentException.class)
+				.satisfies(ex -> assertThat(((PaymentException)ex).getErrorCode())
+						.isEqualTo(ErrorCode.PAYMENT_RESERVATION_FAILED));
+
+		verifyNoInteractions(paymentClient, paymentQueuePublisher);
+	}
+
+	@Test
+	@DisplayName("결제 확정 실패 - 금액이 슬롯 예약금과 다르면 예외가 발생한다")
+	void approve_fail_amountMismatch() {
+		// given
+		PaymentConfirmRequestDto wrongAmountDto = new PaymentConfirmRequestDto(PAYMENT_KEY, IDEMPOTENCY_KEY, 99999);
+
+		given(reservationRepository.fetchByIdempotencyKey(IDEMPOTENCY_KEY)).willReturn(pendingReservation);
+		given(restaurantSlotRepository.fetchById(SLOT_ID)).willReturn(slot);
+
+		// when & then
+		assertThatThrownBy(() -> paymentService.approve(USER_ID, wrongAmountDto))
+				.isInstanceOf(PaymentException.class)
+				.satisfies(ex -> assertThat(((PaymentException)ex).getErrorCode())
+						.isEqualTo(ErrorCode.PAYMENT_AMOUNT_MISMATCH));
+
+		verifyNoInteractions(paymentClient, paymentQueuePublisher);
+	}
+
+	@Test
+	@DisplayName("결제 확정 실패 - 5xx 오류 시 TOSS_API_UNAVAILABLE 예외가 발생한다")
+	void approve_fail_tossServerError() {
+		// given
+		given(reservationRepository.fetchByIdempotencyKey(IDEMPOTENCY_KEY)).willReturn(pendingReservation);
+		given(restaurantSlotRepository.fetchById(SLOT_ID)).willReturn(slot);
+		given(paymentClient.confirm(any(PaymentRequest.class)))
+				.willThrow(HttpServerErrorException.class);
+
+		// when & then
+		assertThatThrownBy(() -> paymentService.approve(USER_ID, requestDto))
+				.isInstanceOf(PaymentException.class)
+				.satisfies(ex -> assertThat(((PaymentException)ex).getErrorCode())
+						.isEqualTo(ErrorCode.TOSS_API_UNAVAILABLE));
+
+		verify(reservationRepository).updatePaymentKey(pendingReservation);
+		verify(paymentQueuePublisher, never()).publish(any());
+	}
+}

--- a/src/test/java/com/reservation/tablereservationservice/application/reservation/scheduler/PendingReservationExpireSchedulerTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/reservation/scheduler/PendingReservationExpireSchedulerTest.java
@@ -1,0 +1,242 @@
+package com.reservation.tablereservationservice.application.reservation.scheduler;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.reservation.tablereservationservice.application.payment.PaymentClient;
+import com.reservation.tablereservationservice.application.payment.PaymentResult;
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacity;
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacityRepository;
+import com.reservation.tablereservationservice.domain.reservation.Reservation;
+import com.reservation.tablereservationservice.domain.reservation.ReservationRepository;
+import com.reservation.tablereservationservice.domain.reservation.ReservationStatus;
+import com.reservation.tablereservationservice.fixture.DailySlotCapacityFixture;
+import com.reservation.tablereservationservice.fixture.ReservationFixture;
+import com.reservation.tablereservationservice.global.config.ReservationStreamProperties;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.PaymentException;
+import com.reservation.tablereservationservice.infrastructure.payment.messaging.PaymentQueueMessage;
+import com.reservation.tablereservationservice.infrastructure.payment.messaging.PaymentQueuePublisher;
+import com.reservation.tablereservationservice.infrastructure.redis.ReservationPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class PendingReservationExpireSchedulerTest {
+
+	private static final int THRESHOLD_SECONDS = 600;
+	private static final Long SLOT_ID = 10L;
+	private static final int PARTY_SIZE = 2;
+	private static final LocalDate VISIT_DATE = LocalDate.of(2030, 1, 1);
+	private static final int INITIAL_REMAINING = 4;
+	private static final String PAYMENT_KEY = "toss-key-1";
+
+	@Mock
+	private ReservationRepository reservationRepository;
+
+	@Mock
+	private DailySlotCapacityRepository dailySlotCapacityRepository;
+
+	@Mock
+	private ReservationPublisher reservationPublisher;
+
+	@Mock
+	private ReservationStreamProperties streamProperties;
+
+	@Mock
+	private PaymentClient paymentClient;
+
+	@Mock
+	private PaymentQueuePublisher paymentQueuePublisher;
+
+	@InjectMocks
+	private PendingReservationExpireScheduler scheduler;
+
+	private Reservation pendingReservation;
+	private DailySlotCapacity capacity;
+
+	@BeforeEach
+	void setUp() {
+		given(streamProperties.getPendingExpireThresholdSeconds()).willReturn(THRESHOLD_SECONDS);
+
+		pendingReservation = ReservationFixture.pending()
+				.reservationId(1L)
+				.slotId(SLOT_ID)
+				.partySize(PARTY_SIZE)
+				.visitAt(VISIT_DATE.atTime(19, 0))
+				.idempotencyKey("order-uuid-1")
+				.paymentKey(PAYMENT_KEY)
+				.build();
+
+		capacity = DailySlotCapacityFixture.capacity()
+				.capacityId(100L)
+				.slotId(SLOT_ID)
+				.date(VISIT_DATE)
+				.remainingCount(INITIAL_REMAINING)
+				.build();
+	}
+
+	@Test
+	@DisplayName("만료 대상 없음 - 결제 조회 없이 종료한다")
+	void expirePendingReservations_noExpired_doesNothing() {
+		given(reservationRepository.findPendingBefore(any(LocalDateTime.class))).willReturn(List.of());
+
+		scheduler.expirePendingReservations();
+
+		verifyNoInteractions(paymentClient, paymentQueuePublisher, dailySlotCapacityRepository, reservationPublisher);
+	}
+
+	@Test
+	@DisplayName("paymentKey 없음 - 결제 조회 없이 즉시 PAYMENT_FAILED로 처리한다")
+	void expirePendingReservations_noPaymentKey_failsWithoutTossQuery() {
+		Reservation noKeyReservation = ReservationFixture.pending()
+				.reservationId(2L)
+				.slotId(SLOT_ID)
+				.partySize(PARTY_SIZE)
+				.visitAt(VISIT_DATE.atTime(19, 0))
+				.idempotencyKey("order-uuid-2")
+				.build();
+		given(reservationRepository.findPendingBefore(any())).willReturn(List.of(noKeyReservation));
+		given(dailySlotCapacityRepository.findBySlotIdAndDate(SLOT_ID, VISIT_DATE)).willReturn(Optional.of(capacity));
+
+		scheduler.expirePendingReservations();
+
+		assertThat(noKeyReservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_FAILED);
+		verify(reservationRepository).updateStatus(noKeyReservation);
+		verifyNoInteractions(paymentClient, paymentQueuePublisher);
+	}
+
+	@Test
+	@DisplayName("결제 조회 성공 (DONE) - 큐에 메시지를 발행하고 예약 상태를 바꾸지 않는다")
+	void expirePendingReservations_tossQueryDone_publishesMessage() {
+		PaymentResult doneResult = new PaymentResult(
+				PAYMENT_KEY, "order-uuid-1", 10000,
+				OffsetDateTime.of(2030, 1, 1, 10, 0, 0, 0, ZoneOffset.UTC),
+				"DONE"
+		);
+		given(reservationRepository.findPendingBefore(any())).willReturn(List.of(pendingReservation));
+		given(paymentClient.queryByPaymentKey(PAYMENT_KEY)).willReturn(doneResult);
+
+		scheduler.expirePendingReservations();
+
+		ArgumentCaptor<PaymentQueueMessage> captor = ArgumentCaptor.forClass(PaymentQueueMessage.class);
+		verify(paymentQueuePublisher).publish(captor.capture());
+		assertThat(captor.getValue().getReservationId()).isEqualTo(1L);
+		assertThat(captor.getValue().getIdempotencyKey()).isEqualTo("order-uuid-1");
+
+		assertThat(pendingReservation.getStatus()).isEqualTo(ReservationStatus.PENDING);
+		verifyNoInteractions(dailySlotCapacityRepository, reservationPublisher);
+	}
+
+	@Test
+	@DisplayName("Toss 조회 성공 (미완료) - PAYMENT_FAILED로 처리하고 좌석을 복원한다")
+	void expirePendingReservations_tossQueryNotDone_failsReservation() {
+		PaymentResult notDoneResult = new PaymentResult(
+				null, "order-uuid-1", null, null, "ABORTED"
+		);
+		given(reservationRepository.findPendingBefore(any())).willReturn(List.of(pendingReservation));
+		given(paymentClient.queryByPaymentKey(PAYMENT_KEY)).willReturn(notDoneResult);
+		given(dailySlotCapacityRepository.findBySlotIdAndDate(SLOT_ID, VISIT_DATE)).willReturn(Optional.of(capacity));
+
+		scheduler.expirePendingReservations();
+
+		assertThat(pendingReservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_FAILED);
+		verify(reservationRepository).updateStatus(pendingReservation);
+		verify(paymentQueuePublisher, never()).publish(any());
+	}
+
+	@Test
+	@DisplayName("Toss 조회 실패 (PaymentException) - PAYMENT_FAILED로 처리하고 좌석을 복원한다")
+	void expirePendingReservations_tossQueryFails_failsReservation() {
+		given(reservationRepository.findPendingBefore(any())).willReturn(List.of(pendingReservation));
+		given(paymentClient.queryByPaymentKey(PAYMENT_KEY)).willThrow(new PaymentException(ErrorCode.TOSS_API_UNAVAILABLE));
+		given(dailySlotCapacityRepository.findBySlotIdAndDate(SLOT_ID, VISIT_DATE)).willReturn(Optional.of(capacity));
+
+		scheduler.expirePendingReservations();
+
+		assertThat(pendingReservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_FAILED);
+		verify(reservationRepository).updateStatus(pendingReservation);
+		verify(paymentQueuePublisher, never()).publish(any());
+	}
+
+	@Test
+	@DisplayName("만료 처리 - 좌석이 DB와 Redis에 복원된다")
+	void expirePendingReservations_fail_restoresSeatCapacity() {
+		given(reservationRepository.findPendingBefore(any())).willReturn(List.of(pendingReservation));
+		given(paymentClient.queryByPaymentKey(PAYMENT_KEY)).willThrow(new PaymentException(ErrorCode.TOSS_API_UNAVAILABLE));
+		given(dailySlotCapacityRepository.findBySlotIdAndDate(SLOT_ID, VISIT_DATE)).willReturn(Optional.of(capacity));
+
+		scheduler.expirePendingReservations();
+
+		assertThat(capacity.getRemainingCount()).isEqualTo(INITIAL_REMAINING + PARTY_SIZE);
+		verify(dailySlotCapacityRepository).updateRemainingCount(capacity);
+		verify(reservationPublisher).releaseSeat(SLOT_ID, VISIT_DATE, PARTY_SIZE);
+	}
+
+	@Test
+	@DisplayName("만료 처리 - DailySlotCapacity가 없어도 예약 상태는 PAYMENT_FAILED로 변경된다")
+	void expirePendingReservations_capacityNotFound_stillFailsReservation() {
+		given(reservationRepository.findPendingBefore(any())).willReturn(List.of(pendingReservation));
+		given(paymentClient.queryByPaymentKey(PAYMENT_KEY)).willThrow(new PaymentException(ErrorCode.TOSS_API_UNAVAILABLE));
+		given(dailySlotCapacityRepository.findBySlotIdAndDate(SLOT_ID, VISIT_DATE)).willReturn(Optional.empty());
+
+		scheduler.expirePendingReservations();
+
+		assertThat(pendingReservation.getStatus()).isEqualTo(ReservationStatus.PAYMENT_FAILED);
+		verify(reservationRepository).updateStatus(pendingReservation);
+		verify(dailySlotCapacityRepository, never()).updateRemainingCount(any());
+	}
+
+	@Test
+	@DisplayName("만료 처리 - 여러 건이 모두 처리된다")
+	void expirePendingReservations_multipleExpired_processesAll() {
+		Reservation reservation1 = ReservationFixture.pending()
+				.reservationId(1L).slotId(SLOT_ID).partySize(2).visitAt(VISIT_DATE.atTime(18, 0)).build();
+		Reservation reservation2 = ReservationFixture.pending()
+				.reservationId(2L).slotId(SLOT_ID).partySize(1).visitAt(VISIT_DATE.atTime(19, 0)).build();
+		Reservation reservation3 = ReservationFixture.pending()
+				.reservationId(3L).slotId(SLOT_ID).partySize(3).visitAt(VISIT_DATE.atTime(20, 0)).build();
+
+		given(reservationRepository.findPendingBefore(any())).willReturn(List.of(reservation1, reservation2, reservation3));
+		given(dailySlotCapacityRepository.findBySlotIdAndDate(eq(SLOT_ID), any())).willReturn(Optional.of(capacity));
+
+		scheduler.expirePendingReservations();
+
+		assertThat(reservation1.getStatus()).isEqualTo(ReservationStatus.PAYMENT_FAILED);
+		assertThat(reservation2.getStatus()).isEqualTo(ReservationStatus.PAYMENT_FAILED);
+		assertThat(reservation3.getStatus()).isEqualTo(ReservationStatus.PAYMENT_FAILED);
+		verify(reservationRepository, times(3)).updateStatus(any());
+		verify(reservationPublisher, times(3)).releaseSeat(eq(SLOT_ID), any(), anyInt());
+		verifyNoInteractions(paymentClient);
+	}
+
+	@Test
+	@DisplayName("만료 기준 시각이 현재로부터 정확히 10분(600초) 이전으로 계산된다")
+	void expirePendingReservations_queryThreshold_isBeforeThreshold() {
+		given(reservationRepository.findPendingBefore(any())).willReturn(List.of());
+
+		LocalDateTime before = LocalDateTime.now().minusSeconds(THRESHOLD_SECONDS);
+
+		scheduler.expirePendingReservations();
+
+		ArgumentCaptor<LocalDateTime> captor = ArgumentCaptor.forClass(LocalDateTime.class);
+		verify(reservationRepository).findPendingBefore(captor.capture());
+		assertThat(captor.getValue()).isBefore(LocalDateTime.now().minusSeconds(THRESHOLD_SECONDS - 1));
+		assertThat(captor.getValue()).isAfterOrEqualTo(before.minusSeconds(1));
+	}
+}

--- a/src/test/java/com/reservation/tablereservationservice/application/reservation/scheduler/RedisReconciliationSchedulerTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/reservation/scheduler/RedisReconciliationSchedulerTest.java
@@ -1,0 +1,102 @@
+package com.reservation.tablereservationservice.application.reservation.scheduler;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacity;
+import com.reservation.tablereservationservice.domain.reservation.DailySlotCapacityRepository;
+import com.reservation.tablereservationservice.fixture.DailySlotCapacityFixture;
+import com.reservation.tablereservationservice.global.config.ReservationStreamProperties;
+
+@ExtendWith(MockitoExtension.class)
+class RedisReconciliationSchedulerTest {
+
+	@Mock
+	private DailySlotCapacityRepository dailySlotCapacityRepository;
+
+	@Mock
+	private StringRedisTemplate redisTemplate;
+
+	@Mock
+	private ReservationStreamProperties streamProperties;
+
+	@Mock
+	private ValueOperations<String, String> valueOperations;
+
+	@InjectMocks
+	private RedisReconciliationScheduler scheduler;
+
+	@Test
+	@DisplayName("재동기화 - 조회된 모든 capacity를 Redis에 갱신한다")
+	void syncCapacityToRedis_success_setsAllKeys() {
+		// given
+		DailySlotCapacity capacity1 = DailySlotCapacityFixture.capacity()
+				.slotId(1L).date(LocalDate.now().plusDays(1)).remainingCount(4).build();
+		DailySlotCapacity capacity2 = DailySlotCapacityFixture.capacity()
+				.slotId(1L).date(LocalDate.now().plusDays(2)).remainingCount(3).build();
+		DailySlotCapacity capacity3 = DailySlotCapacityFixture.capacity()
+				.slotId(2L).date(LocalDate.now().plusDays(1)).remainingCount(2).build();
+
+		given(dailySlotCapacityRepository.findAllFromDate(any(LocalDate.class)))
+				.willReturn(List.of(capacity1, capacity2, capacity3));
+		given(streamProperties.remainingKey(anyLong(), anyString())).willAnswer(inv ->
+				"reservation:remaining:" + inv.getArgument(0) + ":" + inv.getArgument(1));
+		given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+		// when
+		scheduler.syncCapacityToRedis();
+
+		// then
+		verify(valueOperations, times(3)).set(anyString(), anyString(), eq(7L), eq(TimeUnit.DAYS));
+	}
+
+	@Test
+	@DisplayName("재동기화 - Redis 키에 올바른 remaining_count가 저장된다")
+	void syncCapacityToRedis_success_setsCorrectValues() {
+		// given
+		DailySlotCapacity capacity = DailySlotCapacityFixture.capacity()
+				.slotId(1L).date(LocalDate.now().plusDays(1)).remainingCount(3).build();
+
+		given(dailySlotCapacityRepository.findAllFromDate(any())).willReturn(List.of(capacity));
+		given(streamProperties.remainingKey(1L, capacity.getDate().toString()))
+				.willReturn("reservation:remaining:1:" + capacity.getDate());
+		given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+		// when
+		scheduler.syncCapacityToRedis();
+
+		// then
+		verify(valueOperations).set(
+				eq("reservation:remaining:1:" + capacity.getDate()),
+				eq("3"),
+				eq(7L),
+				eq(TimeUnit.DAYS)
+		);
+	}
+
+	@Test
+	@DisplayName("재동기화 - 조회 결과가 없으면 Redis 갱신을 하지 않는다")
+	void syncCapacityToRedis_emptyCapacities_doesNothing() {
+		// given
+		given(dailySlotCapacityRepository.findAllFromDate(any())).willReturn(List.of());
+
+		// when
+		scheduler.syncCapacityToRedis();
+
+		// then
+		verifyNoInteractions(redisTemplate);
+	}
+}

--- a/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/reservation/service/ReservationServiceTest.java
@@ -36,7 +36,6 @@ import com.reservation.tablereservationservice.fixture.UserFixture;
 import com.reservation.tablereservationservice.global.exception.ErrorCode;
 import com.reservation.tablereservationservice.global.exception.ReservationException;
 import com.reservation.tablereservationservice.global.transaction.TransactionHandler;
-import com.reservation.tablereservationservice.infrastructure.stream.ReservationPublisher;
 import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationRequestDto;
 
 @ExtendWith(MockitoExtension.class)
@@ -59,9 +58,6 @@ class ReservationServiceTest {
 
 	@Mock
 	private RestaurantRepository restaurantRepository;
-
-	@Mock
-	private ReservationPublisher reservationPublisher;
 
 	@Mock
 	private NotificationService notificationService;
@@ -105,7 +101,6 @@ class ReservationServiceTest {
 
 		ReservationRequestDto req = new ReservationRequestDto(restaurantSlot.getSlotId(), date, partySize, "note");
 
-		given(reservationRepository.findByIdempotencyKey(idempotencyKey)).willReturn(Optional.empty());
 		given(userRepository.fetchByEmail(customer.getEmail())).willReturn(customer);
 		given(restaurantSlotRepository.fetchById(restaurantSlot.getSlotId())).willReturn(restaurantSlot);
 		given(reservationRepository.existsByUserIdAndVisitAtAndStatusIn(
@@ -147,7 +142,6 @@ class ReservationServiceTest {
 
 		ReservationRequestDto req = new ReservationRequestDto(restaurantSlot.getSlotId(), date, 2, "");
 
-		given(reservationRepository.findByIdempotencyKey(idempotencyKey)).willReturn(Optional.empty());
 		given(userRepository.fetchByEmail(customer.getEmail())).willReturn(customer);
 		given(restaurantSlotRepository.fetchById(restaurantSlot.getSlotId())).willReturn(restaurantSlot);
 		given(reservationRepository.existsByUserIdAndVisitAtAndStatusIn(

--- a/src/test/java/com/reservation/tablereservationservice/fixture/ReservationFixture.java
+++ b/src/test/java/com/reservation/tablereservationservice/fixture/ReservationFixture.java
@@ -25,6 +25,12 @@ public class ReservationFixture {
 	private int partySize = 2;
 	private String note = "note";
 	private ReservationStatus status = ReservationStatus.CONFIRMED;
+	private String idempotencyKey = null;
+	private String paymentKey = null;
+
+	public static ReservationFixture pending() {
+		return new ReservationFixture().status(ReservationStatus.PENDING);
+	}
 
 	public static ReservationFixture confirmed() {
 		return new ReservationFixture().status(ReservationStatus.CONFIRMED);
@@ -34,6 +40,10 @@ public class ReservationFixture {
 		return new ReservationFixture().status(ReservationStatus.CANCELED);
 	}
 
+	public static ReservationFixture paymentFailed() {
+		return new ReservationFixture().status(ReservationStatus.PAYMENT_FAILED);
+	}
+
 	public Reservation build() {
 		Reservation.ReservationBuilder builder = Reservation.builder()
 			.userId(userId)
@@ -41,7 +51,9 @@ public class ReservationFixture {
 			.visitAt(visitAt)
 			.partySize(partySize)
 			.note(note)
-			.status(status);
+			.status(status)
+			.idempotencyKey(idempotencyKey)
+			.paymentKey(paymentKey);
 
 		if (reservationId != null) {
 			builder.reservationId(reservationId);

--- a/src/test/java/com/reservation/tablereservationservice/infrastructure/payment/client/TossPaymentClientResilienceTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/infrastructure/payment/client/TossPaymentClientResilienceTest.java
@@ -1,0 +1,206 @@
+package com.reservation.tablereservationservice.infrastructure.payment.client;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.IOException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+
+import com.reservation.tablereservationservice.application.payment.PaymentClient;
+import com.reservation.tablereservationservice.application.payment.PaymentRequest;
+import com.reservation.tablereservationservice.application.payment.PaymentResult;
+import com.reservation.tablereservationservice.global.exception.PaymentException;
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class TossPaymentClientResilienceTest {
+
+	static MockWebServer mockServer;
+
+	static {
+		mockServer = new MockWebServer();
+		try {
+			mockServer.start();
+		} catch (IOException e) {
+			throw new ExceptionInInitializerError(e);
+		}
+	}
+
+	@DynamicPropertySource
+	static void setProperties(DynamicPropertyRegistry registry) {
+		registry.add("toss.payments.approve-url", () -> mockServer.url("/v1/payments/approve").toString());
+		registry.add("toss.payments.payment-base-url", () -> mockServer.url("/v1/payments").toString());
+	}
+
+	@AfterAll
+	static void tearDown() throws IOException {
+		mockServer.shutdown();
+	}
+
+	@Autowired
+	private PaymentClient paymentClient;
+
+	@Autowired
+	private CircuitBreakerRegistry circuitBreakerRegistry;
+
+	private int requestCountBefore;
+
+	@BeforeEach
+	void setUp() {
+		circuitBreakerRegistry.circuitBreaker("tossPayment").reset();
+		requestCountBefore = mockServer.getRequestCount();
+	}
+
+	@Test
+	@DisplayName("5xx - max-attempts(3)만큼 재시도 후 HttpServerErrorException이 전파된다")
+	void retry_exhausted_on_5xx() {
+		for (int i = 0; i < 3; i++) {
+			mockServer.enqueue(new MockResponse().setResponseCode(500));
+		}
+
+		PaymentRequest request = PaymentRequest.of("key", "order-1", 1000);
+
+		assertThatThrownBy(() -> paymentClient.confirm(request))
+				.isInstanceOf(HttpServerErrorException.class);
+
+		assertThat(mockServer.getRequestCount() - requestCountBefore).isEqualTo(3);
+	}
+
+	@Test
+	@DisplayName("4xx (카드 거절 등) - 재시도 없이 즉시 PaymentException이 전파된다")
+	void no_retry_on_4xx() {
+		mockServer.enqueue(new MockResponse()
+				.setResponseCode(400)
+				.addHeader("Content-Type", "application/json")
+				.setBody("{\"code\":\"CARD_DECLINED\",\"message\":\"카드 한도를 초과했습니다.\"}"));
+
+		PaymentRequest request = PaymentRequest.of("key", "order-1", 1000);
+
+		assertThatThrownBy(() -> paymentClient.confirm(request))
+				.isInstanceOf(PaymentException.class);
+
+		assertThat(mockServer.getRequestCount() - requestCountBefore).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("CB OPEN - HTTP 호출 없이 CallNotPermittedException이 전파된다")
+	void circuit_breaker_open_blocks_call() {
+		circuitBreakerRegistry.circuitBreaker("tossPayment").transitionToOpenState();
+
+		PaymentRequest request = PaymentRequest.of("key", "order-1", 1000);
+
+		assertThatThrownBy(() -> paymentClient.confirm(request))
+				.isInstanceOf(CallNotPermittedException.class);
+
+		assertThat(mockServer.getRequestCount() - requestCountBefore).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("retry → ALREADY_PROCESSED_PAYMENT → queryByPaymentKey 복구")
+	void retry_alreadyProcessed_recoversViaQuery() {
+		// 1차 시도: 네트워크 단절 → ResourceAccessException → @Retry 발동
+		mockServer.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+
+		// 2차 시도(재시도): ALREADY_PROCESSED_PAYMENT → handleClientError → queryByPaymentKey 호출
+		mockServer.enqueue(new MockResponse()
+				.setResponseCode(400)
+				.addHeader("Content-Type", "application/json")
+				.setBody("{\"code\":\"ALREADY_PROCESSED_PAYMENT\",\"message\":\"이미 처리된 결제 입니다.\"}"));
+
+		// queryByPaymentKey 응답
+		mockServer.enqueue(new MockResponse()
+				.setResponseCode(200)
+				.addHeader("Content-Type", "application/json")
+				.setBody("""
+						{"paymentKey":"toss-key-123","orderId":"order-1","totalAmount":1000,"approvedAt":"2030-01-01T19:00:00+09:00","status":"DONE"}
+						"""));
+
+		PaymentRequest request = PaymentRequest.of("toss-key-123", "order-1", 1000);
+
+		PaymentResult result = paymentClient.confirm(request);
+
+		assertThat(result.getPaymentKey()).isEqualTo("toss-key-123");
+		// 네트워크 오류 1회 + ALREADY_PROCESSED 1회 + 단건 조회 1회 = 총 3회
+		assertThat(mockServer.getRequestCount() - requestCountBefore).isEqualTo(3);
+	}
+
+	@Test
+	@DisplayName("4xx는 CB 실패율에 집계되지 않아 연속 발생해도 CB가 열리지 않는다")
+	void circuit_breaker_ignores_4xx_failures() {
+		// sliding-window=4, threshold=100% → 5번 4xx가 와도 CB는 CLOSED 유지
+		for (int i = 0; i < 5; i++) {
+			mockServer.enqueue(new MockResponse()
+					.setResponseCode(400)
+					.addHeader("Content-Type", "application/json")
+					.setBody("{\"code\":\"CARD_DECLINED\",\"message\":\"카드 한도를 초과했습니다.\"}"));
+		}
+
+		PaymentRequest request = PaymentRequest.of("key", "order-1", 1000);
+
+		for (int i = 0; i < 5; i++) {
+			assertThatThrownBy(() -> paymentClient.confirm(request))
+					.isInstanceOf(PaymentException.class);
+		}
+
+		assertThat(circuitBreakerRegistry.circuitBreaker("tossPayment").getState())
+				.isEqualTo(CircuitBreaker.State.CLOSED);
+	}
+
+	@Test
+	@DisplayName("읽기 타임아웃 - max-attempts(3)만큼 재시도 후 ResourceAccessException이 전파된다")
+	void readTimeout_exhausted_triggersRetryAndFails() {
+		// read-timeout-seconds=1 (test.yml), NO_RESPONSE → 서버가 응답을 보내지 않아 타임아웃 발생
+		for (int i = 0; i < 3; i++) {
+			mockServer.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE));
+		}
+
+		PaymentRequest request = PaymentRequest.of("key", "order-1", 1000);
+
+		assertThatThrownBy(() -> paymentClient.confirm(request))
+				.isInstanceOf(ResourceAccessException.class);
+
+		assertThat(mockServer.getRequestCount() - requestCountBefore).isEqualTo(3);
+	}
+
+	@Test
+	@DisplayName("CB - 연속 실패 후 OPEN으로 전환되고 이후 호출은 차단된다")
+	void circuit_breaker_opens_after_threshold_failures() {
+		// sliding-window=4, threshold=100% → 4회 실패 시 OPEN
+		// 각 호출은 3번 재시도 → 호출 1회당 HTTP 요청 3회
+		for (int i = 0; i < 4 * 3; i++) {
+			mockServer.enqueue(new MockResponse().setResponseCode(500));
+		}
+
+		PaymentRequest request = PaymentRequest.of("key", "order-1", 1000);
+
+		for (int i = 0; i < 4; i++) {
+			assertThatThrownBy(() -> paymentClient.confirm(request))
+					.isInstanceOf(HttpServerErrorException.class);
+		}
+
+		assertThat(circuitBreakerRegistry.circuitBreaker("tossPayment").getState())
+				.isEqualTo(CircuitBreaker.State.OPEN);
+
+		// OPEN 상태: 추가 HTTP 요청 없이 즉시 차단
+		assertThatThrownBy(() -> paymentClient.confirm(request))
+				.isInstanceOf(CallNotPermittedException.class);
+
+		assertThat(mockServer.getRequestCount() - requestCountBefore).isEqualTo(12);
+	}
+}

--- a/src/test/java/com/reservation/tablereservationservice/infrastructure/payment/client/TossPaymentClientTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/infrastructure/payment/client/TossPaymentClientTest.java
@@ -1,0 +1,126 @@
+package com.reservation.tablereservationservice.infrastructure.payment.client;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestClient;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.reservation.tablereservationservice.application.payment.PaymentRequest;
+import com.reservation.tablereservationservice.application.payment.PaymentResult;
+import com.reservation.tablereservationservice.global.config.TossPaymentProperties;
+import com.reservation.tablereservationservice.global.exception.PaymentException;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+class TossPaymentClientTest {
+
+	private MockWebServer mockServer;
+	private TossPaymentClient client;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		mockServer = new MockWebServer();
+		mockServer.start();
+
+		TossPaymentProperties properties = new TossPaymentProperties();
+		properties.setConfirmUrl(mockServer.url("/v1/payments/approve").toString());
+		properties.setPaymentBaseUrl(mockServer.url("/v1/payments").toString());
+
+		ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+		RestClient restClient = RestClient.builder().build();
+
+		client = new TossPaymentClient(properties, restClient, objectMapper);
+	}
+
+	@AfterEach
+	void tearDown() throws Exception {
+		mockServer.shutdown();
+	}
+
+	@Test
+	@DisplayName("200 응답 - PaymentResult를 정상적으로 파싱한다")
+	void confirm_success_parsesPaymentResult() {
+		mockServer.enqueue(new MockResponse()
+				.setResponseCode(200)
+				.addHeader("Content-Type", "application/json")
+				.setBody("""
+						{
+						  "paymentKey": "toss-key-123",
+						  "orderId": "order-uuid-1",
+						  "totalAmount": 10000,
+						  "approvedAt": "2030-01-01T19:00:00+09:00"
+						}
+						"""));
+
+		PaymentResult result = client.confirm(
+				PaymentRequest.of("toss-key-123", "order-uuid-1", 10000));
+
+		assertThat(result.getPaymentKey()).isEqualTo("toss-key-123");
+		assertThat(result.getOrderId()).isEqualTo("order-uuid-1");
+		assertThat(result.getTotalAmount()).isEqualTo(10000);
+		assertThat(result.getApprovedAt()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("4xx 응답 (카드 거절 등) - PaymentException(PAYMENT_FAILED)이 발생한다")
+	void confirm_cardDeclined_throwsPaymentException() {
+		mockServer.enqueue(new MockResponse()
+				.setResponseCode(400)
+				.addHeader("Content-Type", "application/json")
+				.setBody("""
+						{"code":"CARD_DECLINED","message":"카드 한도를 초과했습니다."}
+						"""));
+
+		assertThatThrownBy(() -> client.confirm(
+				PaymentRequest.of("bad-key", "order-1", 10000)))
+				.isInstanceOf(PaymentException.class);
+	}
+
+	@Test
+	@DisplayName("ALREADY_PROCESSED_PAYMENT - paymentKey로 단건 조회 결과를 반환한다")
+	void confirm_alreadyProcessed_queriesAndReturnsResult() {
+		mockServer.enqueue(new MockResponse()
+				.setResponseCode(400)
+				.addHeader("Content-Type", "application/json")
+				.setBody("""
+						{"code":"ALREADY_PROCESSED_PAYMENT","message":"이미 처리된 결제 입니다."}
+						"""));
+
+		mockServer.enqueue(new MockResponse()
+				.setResponseCode(200)
+				.addHeader("Content-Type", "application/json")
+				.setBody("""
+						{
+						  "paymentKey": "toss-key-123",
+						  "orderId": "order-uuid-1",
+						  "totalAmount": 10000,
+						  "approvedAt": "2030-01-01T19:00:00+09:00",
+						  "status": "DONE"
+						}
+						"""));
+
+		PaymentResult result = client.confirm(
+				PaymentRequest.of("toss-key-123", "order-uuid-1", 10000));
+
+		assertThat(result.getPaymentKey()).isEqualTo("toss-key-123");
+		assertThat(result.getOrderId()).isEqualTo("order-uuid-1");
+		assertThat(result.getTotalAmount()).isEqualTo(10000);
+	}
+
+	@Test
+	@DisplayName("5xx 응답 - HttpServerErrorException이 발생한다")
+	void confirm_5xx_throwsHttpServerErrorException() {
+		mockServer.enqueue(new MockResponse().setResponseCode(500));
+
+		assertThatThrownBy(() -> client.confirm(
+				PaymentRequest.of("key", "order-1", 10000)))
+				.isInstanceOf(HttpServerErrorException.class);
+	}
+}

--- a/src/test/java/com/reservation/tablereservationservice/infrastructure/payment/messaging/PaymentQueueListenerTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/infrastructure/payment/messaging/PaymentQueueListenerTest.java
@@ -1,0 +1,71 @@
+package com.reservation.tablereservationservice.infrastructure.payment.messaging;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import com.reservation.tablereservationservice.application.payment.PaymentResult;
+import com.reservation.tablereservationservice.application.payment.service.PaymentConfirmationService;
+import com.reservation.tablereservationservice.fixture.ReservationFixture;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentQueueListenerTest {
+
+	@Mock
+	private PaymentConfirmationService paymentConfirmationService;
+
+	@InjectMocks
+	private PaymentQueueListener listener;
+
+	private PaymentQueueMessage message;
+
+	@BeforeEach
+	void setUp() {
+		PaymentResult result = new PaymentResult(
+				"toss-key", "order-uuid", 10000,
+				OffsetDateTime.of(2030, 1, 1, 19, 0, 0, 0, ZoneOffset.ofHours(9)),
+				"DONE"
+		);
+		message = PaymentQueueMessage.ofConfirmed(
+				ReservationFixture.pending().reservationId(1L).build(), "order-uuid", result);
+	}
+
+	@Test
+	@DisplayName("정상 처리 - approve()을 호출하고 예외 없이 종료한다")
+	void handlePaymentConfirm_success() {
+		willDoNothing().given(paymentConfirmationService).confirm(message);
+
+		assertThatCode(() -> listener.handlePaymentConfirm(message)).doesNotThrowAnyException();
+		verify(paymentConfirmationService).confirm(message);
+	}
+
+	@Test
+	@DisplayName("기술적 오류 - 예외를 re-throw해 NACK 처리한다")
+	void handlePaymentConfirm_technicalError_rethrows() {
+		RuntimeException cause = new RuntimeException("DB timeout");
+		willThrow(cause).given(paymentConfirmationService).confirm(message);
+
+		assertThatThrownBy(() -> listener.handlePaymentConfirm(message))
+				.isSameAs(cause);
+	}
+
+	@Test
+	@DisplayName("중복 메시지 - DataIntegrityViolationException은 ack 처리한다")
+	void handlePaymentConfirm_duplicateMessage_acks() {
+		willThrow(new DataIntegrityViolationException("Duplicate entry"))
+				.given(paymentConfirmationService).confirm(message);
+
+		assertThatCode(() -> listener.handlePaymentConfirm(message)).doesNotThrowAnyException();
+	}
+}

--- a/src/test/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationControllerIntegrationTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationControllerIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Set;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -126,10 +127,8 @@ class ReservationControllerIntegrationTest {
 	}
 
 	private void cleanupRedis() {
-		var remaining = redisTemplate.keys(streamProperties.getRemainingKeyPrefix() + "*");
+		Set<String> remaining = redisTemplate.keys(streamProperties.getRemainingKeyPrefix() + "*");
 		if (remaining != null && !remaining.isEmpty()) redisTemplate.delete(remaining);
-		var pending = redisTemplate.keys(streamProperties.getPendingKeyPrefix() + "*");
-		if (pending != null && !pending.isEmpty()) redisTemplate.delete(pending);
 	}
 
 	@Test

--- a/src/test/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/presentation/reservation/controller/ReservationControllerTest.java
@@ -35,6 +35,7 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.reservation.tablereservationservice.application.reservation.facade.ReservationFacade;
 import com.reservation.tablereservationservice.application.reservation.facade.ReservationOptimisticFacade;
 import com.reservation.tablereservationservice.domain.user.User;
 import com.reservation.tablereservationservice.application.reservation.service.ReservationCreateResult;
@@ -63,6 +64,9 @@ class ReservationControllerTest {
 
 	@MockitoBean
 	private ReservationService reservationService;
+
+	@MockitoBean
+	private ReservationFacade reservationFacade;
 
 	@MockitoBean
 	private ReservationOptimisticFacade reservationOptimisticFacade;
@@ -103,7 +107,7 @@ class ReservationControllerTest {
 			.idempotencyKey(idempotencyKey)
 			.build();
 
-		given(reservationService.reserve(eq(email), any(ReservationRequestDto.class), eq(idempotencyKey)))
+		given(reservationFacade.reserve(eq(email), any(ReservationRequestDto.class), eq(idempotencyKey)))
 			.willReturn(new ReservationCreateResult(reservation, 10000));
 
 		Authentication auth = new UsernamePasswordAuthenticationToken(
@@ -138,7 +142,7 @@ class ReservationControllerTest {
 		assertThat(data.getStatus()).isEqualTo(ReservationStatus.PENDING);
 		assertThat(data.getDepositAmount()).isEqualTo(10000);
 
-		verify(reservationService).reserve(eq(email), any(ReservationRequestDto.class), eq(idempotencyKey));
+		verify(reservationFacade).reserve(eq(email), any(ReservationRequestDto.class), eq(idempotencyKey));
 	}
 
 	@Test
@@ -185,7 +189,7 @@ class ReservationControllerTest {
 		assertThat(errors.get("date")).isEqualTo("예약 날짜는 필수입니다.");
 		assertThat(errors.get("partySize")).isEqualTo("예약 인원은 1명 이상이어야 합니다.");
 
-		verify(reservationService, never()).reserve(anyString(), any(), anyString());
+		verify(reservationFacade, never()).reserve(anyString(), any(), anyString());
 	}
 
 	@Test
@@ -214,7 +218,7 @@ class ReservationControllerTest {
 			.andExpect(status().isForbidden());
 
 		// then
-		verify(reservationService, never()).reserve(anyString(), any(), anyString());
+		verify(reservationFacade, never()).reserve(anyString(), any(), anyString());
 	}
 
 	@Test


### PR DESCRIPTION
## 개요
- 예약 생성 이후 Toss Payments API를 통해 결제 승인을 처리 로직 추가
- 비동기 큐를 통해 예약 확정 처리
- 메시징 아키텍처 변경 — Redis Streams → RabbitMQ

## 주요 설계 사항
### 1. 비동기 확정 구조
- 결제 승인 성공 즉시 응답하고, 예약 확정(DB 상태 변경 + 알림)은 RabbitMQ 컨슈머가 처리한다. (API 응답 시간을 결제 확정 처리와 분리)

### 2. Toss API 호출 (외부 API 연동)
- CircuitBreaker - 슬라이딩 윈도우 10, 실패율 50% 초과 시 OPEN
- HALF_OPEN에서 3회 테스트
- Retry - 최대 3회, 5xx/네트워크 오류 대상
- 4xx(카드 거절 등)는 재시도 및 CB 집계에서 제외해 정상적인 클라이언트 오류가 서킷을 열지 않도록 한다.
- `ALREADY_PROCESSED_PAYMENT` 복구: 재시도 중 Toss가 이미 처리된 결제라고 응답하면, `queryByPaymentKey`로 결제 결과를
  조회해 정상 처리한다. 이를 통해 네트워크 단절 후 재시도 시 중복 승인 없이 결과를 가져올 수 있다.
  
### 3. 멱등성 설계
- 결제 테이블에 `idempotency_key` UNIQUE 제약 추가
- 큐 메시지가 중복 전달되더라도 reservation.status != PENDING 체크가 guard 역할을 하고, 동시 진입 시 DB 제약 위반으로 롤백 후 ACK 처리된다.

### 4. PENDING 예약 만료 스케줄러
- PENDING 상태가 10분 이상 지속된 예약을 대상으로, paymentKey가 있으면 Toss에 결제 상태를 조회한다.
- 만약 결제 승인 상태 (DONE)이면 큐에 재발행(복구), 아니면 PAYMENT_FAILED 처리 후 좌석을 복원한다.

### 5. Redis 동기화 스케줄러
- Redis 장애 후 재시작 시 DB 기준으로 잔여 좌석 수를 재동기화

### 6. Redis Streams가 아닌 RabbitMQ를 선택한 이유
- 기존 Redis Streams는 예약 생성 시 좌석 선점 이벤트를 처리하는 용도였으며, 메시지가 유실되더라도 스케줄러나 재시도로 보정할 수 있는 수준의 요구사항이었다.
- 하지만 결제 도메인은 높은 신뢰성이 요구되며, 메시지 유실이 금전적 손해로 이어질 가능성이 존재하므로 안정성을 보장하는 전용 메시지 브로커를 사용한다.
- Redis의 역할은 좌석 잔여수 관리(캐시 레이어)로 한정하고, 결제 확정이라는 비즈니스 이벤트 처리는 전용 메시지 브로커에 위임해 관심사를 분리한다.

## TODO
- 예약 취소 시 환불 처리 — CONFIRMED 예약 취소 시 Toss 환불 API(POST /v1/payments/{paymentKey}/cancel) 호출 미구현.
- 현재는 상태만 CANCELLED로 변경됨

## References
- https://docs.tosspayments.com/reference
- https://docs.tosspayments.com/reference/error-codes

## 체크리스트
- [x] PR 제목을 명령형으로 작성했습니다.
- [x] PR을 연관되는 github issue에 연결했습니다.
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트 코드가 필요없는 이유가 있습니다.

## 관련 이슈
- closed #32
