### PR TITLE
Redis Sentinel 구성 및 부하 테스트 환경 개선

### DIFF
--- a/db/mysql/init/seed.sql
+++ b/db/mysql/init/seed.sql
@@ -3,6 +3,20 @@ INSERT INTO users (user_id, email, password, name, phone, user_role) VALUES
 (1, 'owner@test.com',    '{noop}Test1234@', '점주',   '010-1111-1111', 'OWNER'),
 (2, 'customer@test.com', '{noop}Test1234@', '테스터', '010-2222-2222', 'CUSTOMER');
 
+-- 부하 테스트용 가상 고객 (k6: customer1@test.com ~ customer100@test.com)
+INSERT INTO users (email, password, name, phone, user_role)
+SELECT
+    CONCAT('customer', n, '@test.com'),
+    '{noop}Test1234@',
+    CONCAT('tester', n),
+    CONCAT('010-', LPAD(n, 4, '0'), '-0000'),
+    'CUSTOMER'
+FROM (
+    SELECT @row := @row + 1 AS n
+    FROM information_schema.columns, (SELECT @row := 0) r
+    LIMIT 100
+) numbers;
+
 -- 식당 (owner_id = 1)
 -- RG01:강남구 RG02:종로구 RG03:용산구 RG04:서초구 RG05:성동구 RG06:마포구 RG07:영등포구 RG08:송파구 RG09:양천구
 -- CT01:한식 CT02:일식 CT03:중식 CT04:스테이크 CT05:이탈리안 CT06:디저트 CT07:정육 CT08:해산물 CT09:주류/바

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,15 @@
 version: '3.7'
 name: table-reservation-service
 
+networks:
+  app-net:
+    external: true
+  monitor-net:
+    external: true
+
 services:
   spring:
     container_name: spring
-    deploy:
-      resources:
-        limits:
-          cpus: "1.0"
-          memory: 1024M
-        reservations:
-          cpus: "1.0"
-          memory: 1024M
     build:
       context: .
       dockerfile: Dockerfile
@@ -20,25 +18,27 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
-      redis:
+      redis-master:
+        condition: service_healthy
+      redis-sentinel-1:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       JAVA_TOOL_OPTIONS: "-Xms256m -Xmx768m"
-
-  mysql:
-    image: mysql:8.4
-    container_name: mysql
+    networks:
+      - app-net     # 앱 내부 서비스 통신
+      - monitor-net # prometheus가 actuator 메트릭 수집
     deploy:
       resources:
         limits:
           cpus: "1.0"
           memory: 1024M
-        reservations:
-          cpus: "1.0"
-          memory: 1024M
+
+  mysql:
+    image: mysql:8.4
+    container_name: mysql
     restart: always
     ports:
       - "3307:3306"
@@ -47,21 +47,28 @@ services:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       TZ: Asia/Seoul
       LANG: C.UTF-8
-    healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-      interval: 5s
-      timeout: 3s
-      retries: 5
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
     volumes:
       - ./db/mysql/data:/var/lib/mysql
       - ./db/mysql/init:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    networks:
+      - app-net     # app-net에만 속해 모니터링 네트워크에서 직접 접근 불가
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1024M
 
-  redis:
+  redis-master:
     image: redis:7-alpine
-    container_name: redis
+    container_name: redis-master
     ports:
       - "6379:6379"
     healthcheck:
@@ -69,6 +76,106 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+    networks:
+      - app-net
+
+  redis-replica:
+    image: redis:7-alpine
+    container_name: redis-replica
+    command: redis-server --replicaof redis-master 6379
+    ports:
+      - "6380:6379"
+    depends_on:
+      redis-master:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    networks:
+      - app-net
+
+  redis-sentinel-1:
+    image: bitnami/redis-sentinel:latest
+    container_name: redis-sentinel-1
+    ports:
+      - "26379:26379"
+    environment:
+      REDIS_SENTINEL_MASTER_NAME: mymaster
+      REDIS_MASTER_HOST: redis-master
+      REDIS_MASTER_PORT_NUMBER: 6379
+      REDIS_SENTINEL_QUORUM: 2
+      REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS: 3000
+      REDIS_SENTINEL_FAILOVER_TIMEOUT: 10000
+      REDIS_SENTINEL_PARALLEL_SYNCS: 1
+      ALLOW_EMPTY_PASSWORD: yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "26379", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    depends_on:
+      redis-master:
+        condition: service_healthy
+      redis-replica:
+        condition: service_healthy
+    networks:
+      - app-net
+
+  redis-sentinel-2:
+    image: bitnami/redis-sentinel:latest
+    container_name: redis-sentinel-2
+    ports:
+      - "26380:26379"
+    environment:
+      REDIS_SENTINEL_MASTER_NAME: mymaster
+      REDIS_MASTER_HOST: redis-master
+      REDIS_MASTER_PORT_NUMBER: 6379
+      REDIS_SENTINEL_QUORUM: 2
+      REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS: 3000
+      REDIS_SENTINEL_FAILOVER_TIMEOUT: 10000
+      REDIS_SENTINEL_PARALLEL_SYNCS: 1
+      ALLOW_EMPTY_PASSWORD: yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "26379", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    depends_on:
+      redis-master:
+        condition: service_healthy
+      redis-replica:
+        condition: service_healthy
+    networks:
+      - app-net
+
+  redis-sentinel-3:
+    image: bitnami/redis-sentinel:latest
+    container_name: redis-sentinel-3
+    ports:
+      - "26381:26379"
+    environment:
+      REDIS_SENTINEL_MASTER_NAME: mymaster
+      REDIS_MASTER_HOST: redis-master
+      REDIS_MASTER_PORT_NUMBER: 6379
+      REDIS_SENTINEL_QUORUM: 2
+      REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS: 3000
+      REDIS_SENTINEL_FAILOVER_TIMEOUT: 10000
+      REDIS_SENTINEL_PARALLEL_SYNCS: 1
+      ALLOW_EMPTY_PASSWORD: yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "26379", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    depends_on:
+      redis-master:
+        condition: service_healthy
+      redis-replica:
+        condition: service_healthy
+    networks:
+      - app-net
 
   rabbitmq:
     image: rabbitmq:3-management-alpine
@@ -84,17 +191,5 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
-
-  mysql-exporter:
-    image: prom/mysqld-exporter:v0.14.0
-    container_name: mysql-exporter
-    depends_on:
-      mysql:
-        condition: service_healthy
-    ports:
-      - "9104:9104"
-    environment:
-      DATA_SOURCE_NAME: "root:${MYSQL_ROOT_PASSWORD}@(mysql:3306)/"
-    command:
-      - --collect.global_status
-      - --collect.info_schema.innodb_metrics
+    networks:
+      - app-net

--- a/script/k6/sentinel_failover.js
+++ b/script/k6/sentinel_failover.js
@@ -1,0 +1,68 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter } from 'k6/metrics';
+import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+
+const success      = new Counter('reservation_success');
+const failCapacity = new Counter('reservation_fail_capacity');
+const failOther    = new Counter('reservation_fail_other');
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const SLOT_ID  = __ENV.SLOT_ID  || '5';
+
+// 날짜 풀 — VU마다 다른 날짜를 써서 좌석 고갈 방지
+const DATES = [
+  '2026-06-04', '2026-06-05', '2026-06-06',
+  '2026-06-07', '2026-06-08', '2026-06-09', '2026-06-10',
+];
+
+// 10 VU × 30초 — failover 구간(3~5초)을 커버하는 지속 부하
+export const options = {
+  scenarios: {
+    constant: {
+      executor: 'constant-vus',
+      vus: 10,
+      duration: '30s',
+    },
+  },
+};
+
+export default function () {
+  const vu   = __VU;
+  const iter = __ITER;
+  const date = DATES[(vu + iter) % DATES.length];
+  const email = `customer${vu}@test.com`;
+
+  const res = http.post(
+    `${BASE_URL}/api/reservations`,
+    JSON.stringify({
+      slotId:    parseInt(SLOT_ID),
+      date:      date,
+      partySize: 1,
+      note:      '',
+    }),
+    {
+      headers: {
+        'Content-Type':    'application/json',
+        'X-User-Email':    email,
+        'Idempotency-Key': uuidv4(),
+      },
+      timeout: '10s',
+    }
+  );
+
+  if (res.status === 200 || res.status === 201) {
+    success.add(1);
+  } else if (res.status === 409) {
+    failCapacity.add(1);
+  } else {
+    failOther.add(1);
+    console.error(`[FAIL] vu=${vu} iter=${iter} date=${date} status=${res.status}`);
+  }
+
+  check(res, {
+    '2xx or 409': (r) => r.status === 200 || r.status === 201 || r.status === 409,
+  });
+
+  sleep(0.5);
+}

--- a/script/monitoring/docker-compose.yml
+++ b/script/monitoring/docker-compose.yml
@@ -1,5 +1,24 @@
 version: '3.7'
+
+networks:
+  monitor-net:
+    external: true
+  app-net:
+    external: true
+
 services:
+  mysql-exporter:
+    image: prom/mysqld-exporter:v0.14.0
+    container_name: mysql-exporter
+    environment:
+      DATA_SOURCE_NAME: "root:${MYSQL_ROOT_PASSWORD}@(mysql:3306)/"
+    command:
+      - --collect.global_status
+      - --collect.info_schema.innodb_metrics
+    networks:
+      - app-net     # MySQL에 접근하기 위해 앱 네트워크 참여
+      - monitor-net # Prometheus가 메트릭을 수집하기 위해 모니터링 네트워크 참여
+
   prometheus:
     image: prom/prometheus
     container_name: prometheus
@@ -8,6 +27,11 @@ services:
     ports:
       - "9090:9090"
     restart: always
+    depends_on:
+      - mysql-exporter
+    networks:
+      - monitor-net # 모니터링 네트워크에만 속해 앱 서비스에 직접 접근 불가
+
   grafana:
     image: grafana/grafana
     container_name: grafana
@@ -16,3 +40,5 @@ services:
     restart: always
     depends_on:
       - prometheus
+    networks:
+      - monitor-net

--- a/script/monitoring/prometheus.yml
+++ b/script/monitoring/prometheus.yml
@@ -9,10 +9,10 @@ scrape_configs:
 
   - job_name: "mysqld-exporter"
     static_configs:
-      - targets: ["host.docker.internal:9104"]
+      - targets: ["mysql-exporter:9104"] # monitor-net 안에서 컨테이너 hostname으로 직접 접근
 
   - job_name: "java_application"
     metrics_path: '/actuator/prometheus'
     scrape_interval: 5s
     static_configs:
-      - targets: ["host.docker.internal:8080"]
+      - targets: ["spring:8080"] # spring이 monitor-net에 속해 있어 직접 접근 가능

--- a/src/main/java/com/reservation/tablereservationservice/global/config/SecurityConfig.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.reservation.tablereservationservice.global.config;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -13,6 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import com.reservation.tablereservationservice.global.filter.LoadTestAuthFilter;
 import com.reservation.tablereservationservice.global.jwt.JwtAccessDeniedHandler;
 import com.reservation.tablereservationservice.global.jwt.JwtAuthenticationEntryPoint;
 import com.reservation.tablereservationservice.global.jwt.JwtAuthenticationFilter;
@@ -30,6 +32,9 @@ public class SecurityConfig {
 	private final JwtProvider jwtProvider;
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 	private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+	@Autowired(required = false)
+	private LoadTestAuthFilter loadTestAuthFilter;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -62,6 +67,10 @@ public class SecurityConfig {
 						new JwtAuthenticationFilter(jwtProvider, jwtAuthenticationEntryPoint),
 						UsernamePasswordAuthenticationFilter.class
 				);
+
+		if (loadTestAuthFilter != null) {
+			http.addFilterBefore(loadTestAuthFilter, UsernamePasswordAuthenticationFilter.class);
+		}
 
 		return http.build();
 	}

--- a/src/main/java/com/reservation/tablereservationservice/global/filter/LoadTestAuthFilter.java
+++ b/src/main/java/com/reservation/tablereservationservice/global/filter/LoadTestAuthFilter.java
@@ -1,0 +1,40 @@
+package com.reservation.tablereservationservice.global.filter;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+@Profile("load-test")
+public class LoadTestAuthFilter extends OncePerRequestFilter {
+
+	private static final String HEADER = "X-User-Email";
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		String email = request.getHeader(HEADER);
+
+		if (StringUtils.hasText(email)) {
+			UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+				email, null, List.of(new SimpleGrantedAuthority("ROLE_CUSTOMER"))
+			);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+		}
+
+		filterChain.doFilter(request, response);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,11 @@ spring:
   profiles:
     active: dev
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 server:
   port: 8080
 


### PR DESCRIPTION
## 개요
- Redis 장애 시에도 DB Atomic UPDATE가 최종 방어선 역할을 하는지 실험으로 검증
- Redis Sentinel 설정 추가 및 동작 검증
  
## 작업 내용                                          
### 1. Docker 네트워크 구조 재구성
- **before**: 앱 compose와 모니터링 compose가 각자 독립된 네트워크를 사용해 Prometheus가 `host.docker.internal`을 통해 scrape하는 구조
- **after**: `app-net / monitor-net`으로 명시적으로 분리하고 두 네트워크를 독립적으로 생성해 어느 compose를 재시작해도 서로 영향을 주지 않도록 구성
                                                          
### 2. Redis Sentinel failover 검증 추가
- 실험 결과: redis-master 중단 후 Sentinel이 1.1초 만에 failover 완료, Lettuce가 새 master로 자동 재연결, 재연결 후 서비스 정상 복구 확인

## TODO
- <!--해당 PR이 머지 된 이후에 챙겨야할 부분을 나열해주세요--> 

## References
- <!--사용된 레퍼런스에 대한 링크를 남겨주세요.-->

## 체크리스트
- [x] PR 제목을 명령형으로 작성했습니다.
- [x] PR을 연관되는 github issue에 연결했습니다.
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트 코드가 필요없는 이유가 있습니다.

## 관련 이슈
- closed #issue 번호
