### PR TITLE
예약/결제 흐름의 동시성·재시도 안정성을 개선

### DIFF
--- a/db/mysql/init/schema.sql
+++ b/db/mysql/init/schema.sql
@@ -5,8 +5,8 @@ CREATE TABLE users (
     name        VARCHAR(50)  NOT NULL             COMMENT '이름',
     phone       VARCHAR(20)                       COMMENT '전화번호',
     user_role   VARCHAR(20)  NOT NULL             COMMENT '사용자 역할',
-    created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
-    modified_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시'
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
+    modified_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='사용자';
 
 
@@ -20,8 +20,8 @@ CREATE TABLE restaurant (
     description     TEXT                              COMMENT '설명',
     main_menu_name  VARCHAR(100)                       COMMENT '대표 메뉴명',
     main_menu_price INT                               COMMENT '대표 메뉴 가격',
-    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
-    modified_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    created_at      DATETIME DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
+    modified_at     DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
     CONSTRAINT fk_restaurant_owner
         FOREIGN KEY (owner_id) REFERENCES users(user_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='식당';
@@ -33,8 +33,8 @@ CREATE TABLE restaurant_slot (
     time               TIME   NOT NULL                   COMMENT '예약 시간',
     max_capacity       INT    NOT NULL                   COMMENT '슬롯 최대 수용 인원',
     deposit_per_person INT    NOT NULL DEFAULT 0          COMMENT '인당 예약금',
-    created_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
-    modified_at        TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    created_at         DATETIME DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
+    modified_at        DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
     CONSTRAINT fk_slot_restaurant
         FOREIGN KEY (restaurant_id) REFERENCES restaurant(restaurant_id),
     CONSTRAINT uq_restaurant_time UNIQUE (restaurant_id, time)
@@ -46,8 +46,8 @@ CREATE TABLE daily_slot_capacity (
     slot_id         BIGINT NOT NULL                   COMMENT '슬롯 FK',
     date            DATE   NOT NULL                   COMMENT '날짜',
     remaining_count INT    NOT NULL                   COMMENT '잔여 수량',
-    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
-    modified_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    created_at      DATETIME DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
+    modified_at     DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
     CONSTRAINT fk_capacity_slot
         FOREIGN KEY (slot_id) REFERENCES restaurant_slot(slot_id),
     CONSTRAINT uq_slot_date UNIQUE (slot_id, date)
@@ -64,8 +64,8 @@ CREATE TABLE reservation (
     status          VARCHAR(20)  NOT NULL              COMMENT '예약 상태',
     idempotency_key VARCHAR(36)  UNIQUE                COMMENT '멱등성 키',
     payment_key     VARCHAR(200)                       COMMENT 'Toss 결제 키 (approve 요청 시 저장)',
-    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
-    modified_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    created_at      DATETIME DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
+    modified_at     DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
     CONSTRAINT fk_reservation_user
         FOREIGN KEY (user_id) REFERENCES users(user_id),
     CONSTRAINT fk_reservation_slot
@@ -82,8 +82,8 @@ CREATE TABLE payment (
     amount          INT          NOT NULL              COMMENT '결제 금액',
     status          VARCHAR(10)  NOT NULL              COMMENT '결제 상태',
     approved_at     DATETIME     NOT NULL              COMMENT '결제 승인 일시',
-    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
-    modified_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    created_at      DATETIME DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
+    modified_at     DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
     CONSTRAINT fk_payment_reservation
         FOREIGN KEY (reservation_id) REFERENCES reservation(reservation_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='결제';
@@ -97,8 +97,8 @@ CREATE TABLE notification (
     title           VARCHAR(100) NOT NULL              COMMENT '알림 제목',
     content         VARCHAR(500) NOT NULL              COMMENT '알림 내용',
     is_read         TINYINT(1)   NOT NULL DEFAULT 0    COMMENT '읽음 여부',
-    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
-    modified_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    created_at      DATETIME DEFAULT CURRENT_TIMESTAMP                   COMMENT '생성일시',
+    modified_at     DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
     CONSTRAINT fk_notification_receiver
         FOREIGN KEY (receiver_id) REFERENCES users(user_id),
     CONSTRAINT fk_notification_reservation

--- a/src/main/java/com/reservation/tablereservationservice/application/reservation/aspect/ReservationIdempotencyAspect.java
+++ b/src/main/java/com/reservation/tablereservationservice/application/reservation/aspect/ReservationIdempotencyAspect.java
@@ -56,7 +56,14 @@ public class ReservationIdempotencyAspect {
 
 		if (Boolean.FALSE.equals(acquired)) {
 			String cached = redisTemplate.opsForValue().get(redisKey);
-			if (cached != null && !"PROCESSING".equals(cached)) {
+
+			if ("PROCESSING".equals(cached)) {
+				// 동일 멱등키 요청이 처리 중 — 즉시 차단(잠시 후 재시도).
+				// 락 TTL 만료·Redis 장애로 동시 통과한 예외 케이스는 DB 유니크 제약이 최종 보장한다.
+				log.warn("[IDEMPOTENCY] 처리 중 동시 요청 차단 idempotencyKey={}", idempotencyKey);
+				throw new ReservationException(ErrorCode.RESERVATION_CONCURRENCY_ERROR);
+			}
+			if (cached != null) {
 				try {
 					return buildFromCache(cached);
 				} catch (Exception e) {
@@ -64,10 +71,8 @@ public class ReservationIdempotencyAspect {
 					redisTemplate.delete(redisKey);
 					// 아래 proceed()로 fall-through하여 새 요청으로 처리
 				}
-			} else {
-				// PROCESSING 상태(동시 진입) — DataIntegrityViolationException 안전망으로 처리
-				log.warn("[IDEMPOTENCY] 동시 요청 감지 idempotencyKey={}", idempotencyKey);
 			}
+			// cached == null: 락이 막 해제됨(1차 실패로 삭제 / TTL 만료) → fall-through하여 재처리
 		}
 
 		try {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,10 +61,14 @@ resilience4j:
     instances:
       tossPayment:
         max-attempts: 3
-        wait-duration: 1s
+        wait-duration: 1s                          # 초기 대기 (1차 재시도 전)
+        enable-exponential-backoff: true           # 1s → 2s … 장애 서버에 가중 부하를 주지 않도록 점증
+        exponential-backoff-multiplier: 2
+        enable-randomized-wait: true               # jitter — 동시 재시도가 같은 시점에 몰리는 storm 방지
+        randomized-wait-factor: 0.5
         retry-exceptions:
           - java.io.IOException                                             # 네트워크 단절
-          - org.springframework.web.client.ResourceAccessException          # 연결 타임아웃
+          - org.springframework.web.client.ResourceAccessException          # 연결/읽기 타임아웃
           - org.springframework.web.client.HttpServerErrorException         # Toss 5xx
         ignore-exceptions:
           - org.springframework.web.client.HttpClientErrorException         # 4xx 재시도 금지

--- a/src/test/java/com/reservation/tablereservationservice/application/reservation/aspect/ReservationIdempotencyAspectTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/reservation/aspect/ReservationIdempotencyAspectTest.java
@@ -29,6 +29,8 @@ import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlot;
 import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlotRepository;
 import com.reservation.tablereservationservice.fixture.ReservationFixture;
 import com.reservation.tablereservationservice.fixture.RestaurantSlotFixture;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.ReservationException;
 import com.reservation.tablereservationservice.infrastructure.payment.messaging.CancelQueuePublisher;
 import com.reservation.tablereservationservice.infrastructure.redis.ReservationPublisher;
 import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationRequestDto;
@@ -137,6 +139,22 @@ class ReservationIdempotencyAspectTest {
 		verify(reservationService, times(1)).reserve(anyString(), any(), eq(idempotencyKey));
 		// 두 번째 요청은 proceed 전에 반환되므로 holdSeat도 1회만 호출
 		verify(reservationPublisher, times(1)).holdSeat(anyLong(), any(), anyInt());
+	}
+
+	@Test
+	@DisplayName("처리 중(PROCESSING) 동시 요청 - proceed 없이 409(RESERVATION_CONCURRENCY_ERROR)로 차단")
+	void concurrentRequest_whileProcessing_blockedWith409() {
+		String idempotencyKey = UUID.randomUUID().toString();
+		// 다른 요청이 처리 중인 상태를 Redis에 직접 세팅
+		redisTemplate.opsForValue().set(KEY_PREFIX + idempotencyKey, "PROCESSING");
+
+		assertThatThrownBy(() -> reservationFacade.reserve("user@test.com", req, idempotencyKey))
+				.isInstanceOfSatisfying(ReservationException.class,
+						ex -> assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.RESERVATION_CONCURRENCY_ERROR));
+
+		// 처리 중 차단이므로 proceed 자체가 실행되지 않음 (holdSeat·service 미호출)
+		verify(reservationPublisher, never()).holdSeat(anyLong(), any(), anyInt());
+		verify(reservationService, never()).reserve(anyString(), any(), anyString());
 	}
 
 	@Test

--- a/src/test/java/com/reservation/tablereservationservice/application/reservation/facade/ReservationFacadeRollbackTest.java
+++ b/src/test/java/com/reservation/tablereservationservice/application/reservation/facade/ReservationFacadeRollbackTest.java
@@ -1,0 +1,131 @@
+package com.reservation.tablereservationservice.application.reservation.facade;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.reservation.tablereservationservice.application.reservation.service.ReservationCreateResult;
+import com.reservation.tablereservationservice.application.reservation.service.ReservationService;
+import com.reservation.tablereservationservice.domain.reservation.Reservation;
+import com.reservation.tablereservationservice.domain.reservation.ReservationRepository;
+import com.reservation.tablereservationservice.domain.restaurant.RestaurantSlotRepository;
+import com.reservation.tablereservationservice.fixture.ReservationFixture;
+import com.reservation.tablereservationservice.global.config.ReservationStreamProperties;
+import com.reservation.tablereservationservice.global.exception.ErrorCode;
+import com.reservation.tablereservationservice.global.exception.ReservationException;
+import com.reservation.tablereservationservice.infrastructure.payment.messaging.CancelQueuePublisher;
+import com.reservation.tablereservationservice.presentation.reservation.dto.ReservationRequestDto;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ReservationFacadeRollbackTest {
+
+	private static final Long SLOT_ID = 999L;
+	private static final LocalDate DATE = LocalDate.of(2030, 6, 1);
+	private static final int PARTY_SIZE = 2;
+	private static final int INITIAL_SEAT = 10;
+
+	@Autowired private ReservationFacade facade;
+	@Autowired private StringRedisTemplate redisTemplate;
+	@Autowired private ReservationStreamProperties streamProperties;
+
+	@MockitoBean private ReservationService reservationService;
+	@MockitoBean private ReservationRepository reservationRepository;
+	@MockitoBean private RestaurantSlotRepository restaurantSlotRepository;
+	@MockitoBean private CancelQueuePublisher cancelQueuePublisher;
+
+	private String seatKey;
+
+	@BeforeEach
+	void setUp() {
+		seatKey = streamProperties.remainingKey(SLOT_ID, DATE.toString());
+		redisTemplate.opsForValue().set(seatKey, String.valueOf(INITIAL_SEAT));
+	}
+
+	@AfterEach
+	void tearDown() {
+		redisTemplate.delete(seatKey);
+		Set<String> idempotencyKeys = redisTemplate.keys("reservation:idempotency:*");
+		if (idempotencyKeys != null && !idempotencyKeys.isEmpty()) {
+			redisTemplate.delete(idempotencyKeys);
+		}
+	}
+
+	@Test
+	@DisplayName("reserve() 비즈니스 예외 → holdSeat으로 차감된 Redis 좌석이 복원된다")
+	void reserve_businessException_restoresSeat() {
+		given(reservationService.reserve(any(), any(), any()))
+			.willThrow(new ReservationException(ErrorCode.RESERVATION_DUPLICATED_TIME));
+
+		assertThatThrownBy(() ->
+			facade.reserve("user@test.com", request(), UUID.randomUUID().toString()))
+			.isInstanceOf(ReservationException.class)
+			.extracting(e -> ((ReservationException) e).getErrorCode())
+			.isEqualTo(ErrorCode.RESERVATION_DUPLICATED_TIME);
+
+		assertThat(redisTemplate.opsForValue().get(seatKey))
+			.isEqualTo(String.valueOf(INITIAL_SEAT));
+	}
+
+	@Test
+	@DisplayName("reserve() DB 예외 → holdSeat으로 차감된 Redis 좌석이 복원된다")
+	void reserve_dbException_restoresSeat() {
+		given(reservationService.reserve(any(), any(), any()))
+			.willThrow(new RuntimeException("DB connection failed"));
+
+		assertThatThrownBy(() ->
+			facade.reserve("user@test.com", request(), UUID.randomUUID().toString()))
+			.isInstanceOf(RuntimeException.class);
+
+		assertThat(redisTemplate.opsForValue().get(seatKey))
+			.isEqualTo(String.valueOf(INITIAL_SEAT));
+	}
+
+	@Test
+	@DisplayName("holdSeat 실패(좌석 부족) → reserve()가 호출되지 않는다")
+	void holdSeat_capacityExhausted_doesNotCallService() {
+		redisTemplate.opsForValue().set(seatKey, "0");
+
+		assertThatThrownBy(() ->
+			facade.reserve("user@test.com", request(), UUID.randomUUID().toString()))
+			.isInstanceOf(ReservationException.class)
+			.extracting(e -> ((ReservationException) e).getErrorCode())
+			.isEqualTo(ErrorCode.RESERVATION_CAPACITY_NOT_ENOUGH);
+
+		verify(reservationService, never()).reserve(any(), any(), any());
+	}
+
+	@Test
+	@DisplayName("정상 성공 → Redis 좌석이 partySize만큼 차감된 채로 유지된다")
+	void normalSuccess_seatDecrementedAndNotRestored() {
+		Reservation reservation = ReservationFixture.pending()
+			.reservationId(1L).slotId(SLOT_ID).partySize(PARTY_SIZE).build();
+		given(reservationService.reserve(any(), any(), any()))
+			.willReturn(new ReservationCreateResult(reservation, 10_000));
+		given(reservationRepository.fetchById(1L)).willReturn(reservation);
+
+		facade.reserve("user@test.com", request(), UUID.randomUUID().toString());
+
+		assertThat(redisTemplate.opsForValue().get(seatKey))
+			.isEqualTo(String.valueOf(INITIAL_SEAT - PARTY_SIZE));
+	}
+
+	private ReservationRequestDto request() {
+
+		return new ReservationRequestDto(SLOT_ID, DATE, PARTY_SIZE, "note");
+	}
+}


### PR DESCRIPTION
## 개요
- 예약/결제 흐름의 동시성·재시도 안정성을 개선
- Toss confirm 재시도에 jittered exponential backoff 적용
- 예약 실패(비즈니스/DB 예외) 시 holdSeat으로 선점한 Redis 좌석이 복원되는 보상 로직 검증 추가

## 체크리스트
- [x] PR 제목을 명령형으로 작성했습니다.
- [x] PR을 연관되는 github issue에 연결했습니다.
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트 코드가 필요없는 이유가 있습니다.

## 관련 이슈
- closed #issue 번호
